### PR TITLE
Trim search query (fix issue #5)

### DIFF
--- a/lib/lexin_web/live/dictionary_live.ex
+++ b/lib/lexin_web/live/dictionary_live.ex
@@ -28,7 +28,7 @@ defmodule LexinWeb.DictionaryLive do
   def handle_params(%{"query" => query, "lang" => lang}, _uri, socket) do
     socket =
       assign(socket, %{
-        query: query,
+        query: String.trim(query),
         lang: lang
       })
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:gettext] ++ Mix.compilers(),


### PR DESCRIPTION
Fix for https://github.com/cr0t/lexin/issues/5

Users might be using various auto-completion systems, and sometimes these systems put an automatic whitespace at the end of the suggested word.

Users always have to manually delete this whitespace – it's annoying.

Let's trim the full string to remove any whitespaces around!