### PR TITLE
Fix #2: Put most relevant definition on top

### DIFF
--- a/lib/lexin/dictionary.ex
+++ b/lib/lexin/dictionary.ex
@@ -3,15 +3,15 @@ defmodule Lexin.Dictionary do
   Entrance to the Lexin's dictionary data
   """
 
-  alias Lexin.Dictionary.{Worker, Parser}
+  alias Lexin.Dictionary.Worker
 
   @spec lookup(lang :: String.t(), word :: String.t()) ::
           {:ok, [Lexin.Definition.t()]} | {:error, any()}
   def lookup(lang, word) do
     try do
       case Worker.definitions(lang, word) do
-        {:ok, raw_definitions} ->
-          {:ok, Enum.map(raw_definitions, &Parser.convert/1)}
+        {:ok, definitions} ->
+          {:ok, definitions}
 
         {:error, err} ->
           {:error, err}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.5.4",
+      version: "0.6.0",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:gettext] ++ Mix.compilers(),


### PR DESCRIPTION
Our users noticed the difference between original Lexin service outputand ours – in Lexin Light the most relevant definition was not on the first place in the results.

This is due to how we select data from the dictionary database files – we do not apply any particular order, and it selects just by the way how definitions are stored there (basically, just alphabetically).

With Swedish way of making compounds and current dictionary database structure, it's a little bit tricky to put the most relevant definition simply in SQL-query.

So, in this attempt we are trying to pick the most relevant (spelled exactly as user's query – with some sanitizing) and put it first in the results list.

We tested it with "bil", "fordon", "dammsugare", and "motor". Looks like it work fine. But we might change it to SQL in future – we left TODO.