### PR TITLE
Add Graminfo field to be parsed and shown

### DIFF
--- a/assets/css/serp.css
+++ b/assets/css/serp.css
@@ -6,7 +6,7 @@
   padding-left: 2rem;
 }
 
-.serp_inflections {
+.serp_dimmed {
   color: rgba(0, 0, 0, .5)
 }
 

--- a/lib/lexin/dictionary/parser.ex
+++ b/lib/lexin/dictionary/parser.ex
@@ -19,6 +19,7 @@ defmodule Lexin.Dictionary.Parser do
   defp parse_lang(html) do
     %Lexin.Definition.Lang{
       meaning: child_text(html, "meaning"),
+      graminfo: child_text(html, "graminfo"),
       comment: child_text(html, "comment"),
       translation: child_text(html, "translation"),
       alternate: child_text(html, "alternate"),
@@ -42,8 +43,6 @@ defmodule Lexin.Dictionary.Parser do
     }
   end
 
-  defp parse_contents(nil), do: []
-
   defp parse_contents(htmls) do
     htmls 
     |> Enum.map(fn html ->
@@ -54,8 +53,6 @@ defmodule Lexin.Dictionary.Parser do
       }
     end)
   end
-
-  defp parse_illustrations(nil), do: []
 
   defp parse_illustrations(htmls) do
     htmls
@@ -80,7 +77,6 @@ defmodule Lexin.Dictionary.Parser do
   defp parse_integer(""), do: nil
   defp parse_integer(n), do: String.to_integer(n)
 
-  defp parse_strings(nil), do: []
   defp parse_strings([""]), do: []
   defp parse_strings(list), do: Enum.map(list, &Floki.text/1)
 end

--- a/lib/lexin/types/lang.ex
+++ b/lib/lexin/types/lang.ex
@@ -3,6 +3,7 @@ defmodule Lexin.Definition.Lang do
 
   defstruct [
     :meaning,
+    :graminfo,
     :comment,
     :translation,
     :alternate,
@@ -18,6 +19,7 @@ defmodule Lexin.Definition.Lang do
 
   @type t :: %__MODULE__{
           meaning: String.t() | nil,
+          graminfo: String.t() | nil,
           comment: String.t() | nil,
           translation: String.t() | nil,
           alternate: String.t() | nil,

--- a/lib/lexin_web/live/components/card_component.ex
+++ b/lib/lexin_web/live/components/card_component.ex
@@ -27,6 +27,9 @@ defmodule LexinWeb.CardComponent do
     "turkish" => "swe,tur"
   }
 
+  def graminfo(dfn),
+    do: dfn.base.graminfo |> String.replace("&", dfn.value)
+
   def illustrations(dfn),
     do: dfn.base.illustrations ++ dfn.target.illustrations
 

--- a/lib/lexin_web/live/components/card_component.html.heex
+++ b/lib/lexin_web/live/components/card_component.html.heex
@@ -11,13 +11,19 @@
   </div>
 
   <div class="serp_content">
-    <div class="serp_inflections">
+    <div class="serp_dimmed">
       &lt;<%= Enum.join(inflections(@dfn), ", ") %>&gt;
     </div>
 
     <div>
       <%= @dfn.base.meaning %>
     </div>
+
+    <%= if @dfn.base.graminfo do %>
+      <div class="serp_dimmed">
+        &lt;<%= graminfo(@dfn) %>&gt;
+      </div>
+    <% end %>
 
     <%= if @dfn.base.alternate do %>
       <div>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.6.2",
+      version: "0.6.3",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:gettext] ++ Mix.compilers(),


### PR DESCRIPTION
We noticed a lack of grammar information in Lexin Light that is presented in the original service.

There is optional field `<Graminfo>` in the `<Baselang>` entities in the original XML dictionaries, which we haven't noticed previously:

<img width="684" alt="image" src="https://user-images.githubusercontent.com/113878/148663672-8d5e10f1-4ffa-4dc8-8266-948ce29ba946.png">

We added it to the types in our app, and to the `Parser` code. We also render this information in the search results page (with a little re-formatting of original string – as we understood it observing XML files data and output of original Lexin app).

Fixes #4.