### PR TITLE
Fix antonyms parser and show synonyms correctly

### DIFF
--- a/lib/lexin/dictionary/parser.ex
+++ b/lib/lexin/dictionary/parser.ex
@@ -16,6 +16,8 @@ defmodule Lexin.Dictionary.Parser do
     }
   end
 
+  # TODO: Check and fix parsing according to LexinSchema.xsd. For example, we need to follow
+  # number of occurences for different sub-pieces of definition (only one synonym, for example).
   defp parse_lang(html) do
     %Lexin.Definition.Lang{
       meaning: child_text(html, "meaning"),
@@ -29,7 +31,7 @@ defmodule Lexin.Dictionary.Parser do
       idioms: children(html, "idiom") |> parse_contents(),
       compounds: children(html, "compound") |> parse_contents(),
       illustrations: children(html, "illustration") |> parse_illustrations(),
-      antonyms: children(html, "antonym") |> parse_strings(),
+      antonyms: children(html, "antonym") |> Floki.attribute("value"),
       synonyms: children(html, "synonym") |> parse_strings()
     }
   end

--- a/lib/lexin_web/live/components/card_component.html.heex
+++ b/lib/lexin_web/live/components/card_component.html.heex
@@ -34,14 +34,18 @@
     <%= if @dfn.target.translation do %>
       <div class="serp_translation">
         <%= @dfn.target.translation %>
-        <%= if length(@dfn.target.synonyms) > 0 do %>
-          <span class="serp_translation-synonyms">— <%= Enum.join(@dfn.target.synonyms, ", ") %></span>
-        <% end %>
       </div>
     <% end %>
 
+    <%= if length(@dfn.target.synonyms) > 0 do %>
+      <div class="serp_dimmed">
+        <span class="serp_translation-synonyms">(<%= Enum.join(@dfn.target.synonyms, ", ") %>)</span>
+      </div>
+    <% end %>
+
+
     <%= if length(@dfn.base.antonyms) > 0 do %>
-      <div>
+      <div class="serp_dimmed">
         <%= gettext("Antonyms: %{antonyms}", antonyms: Enum.join(@dfn.base.antonyms, ", ")) %>
       </div>
     <% end %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.6.3",
+      version: "0.6.4",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:gettext] ++ Mix.compilers(),


### PR DESCRIPTION
We wrongly parsed `<Antonym>` in the original XML – we had to take its `Value` attribute value, not the content of the tag. Now it is fixed.

In addition, we also moved rendering of synonyms out of another `if` statement.

P.S. Plus, we have to revisit our parser later and adjust its logic according to the LexinSchema.xsd file, as we noticed some discrepancies from our current understanding of its internal schema.

P.P.S. Fixes #3.

### Screenshots

| Before | After |
|--------|-------|
| <img width="612" alt="image" src="https://user-images.githubusercontent.com/113878/148678246-269a0747-bf33-4aad-b99b-36d73ef4abf8.png"> | <img width="612" alt="image" src="https://user-images.githubusercontent.com/113878/148678252-7667f5ac-cc27-4066-9e07-113bb2f63c37.png"> |
| <img width="612" alt="image" src="https://user-images.githubusercontent.com/113878/148678281-8e9dc826-aeab-4ad5-8389-33911b55c5bf.png"> | <img width="612" alt="image" src="https://user-images.githubusercontent.com/113878/148678296-6a5a8b54-900a-436a-9f04-2a3feb39ebb7.png"> |