### PR TITLE
Improve search and results

### DIFF
--- a/lib/lexin/dictionary.ex
+++ b/lib/lexin/dictionary.ex
@@ -5,14 +5,16 @@ defmodule Lexin.Dictionary do
 
   alias Lexin.Dictionary.Worker
 
-  @spec lookup(lang :: String.t(), word :: String.t()) ::
+  @spec lookup(lang :: String.t(), query :: String.t()) ::
           {:ok, [Lexin.Definition.t()]} | {:error, any()}
-  def lookup(lang, word) do
+  def lookup(lang, query) do
     try do
-      Worker.definitions(lang, word)
+      normalized_query = String.downcase(query)
+
+      Worker.definitions(lang, normalized_query)
     rescue
       error ->
-        information = %{lang: lang, word: word}
+        information = %{lang: lang, query: query}
         Sentry.capture_exception(error, stacktrace: __STACKTRACE__, extra: %{extra: information})
 
         {:error, :exception_processing_request}

--- a/lib/lexin/dictionary/parser.ex
+++ b/lib/lexin/dictionary/parser.ex
@@ -21,6 +21,7 @@ defmodule Lexin.Dictionary.Parser do
   defp parse_lang(html) do
     %Lexin.Definition.Lang{
       meaning: child_text(html, "meaning"),
+      usage: child_text(html, "usage"),
       graminfo: child_text(html, "graminfo"),
       comment: child_text(html, "comment"),
       translation: child_text(html, "translation"),

--- a/lib/lexin/types/lang.ex
+++ b/lib/lexin/types/lang.ex
@@ -3,6 +3,7 @@ defmodule Lexin.Definition.Lang do
 
   defstruct [
     :meaning,
+    :usage,
     :graminfo,
     :comment,
     :translation,
@@ -19,6 +20,7 @@ defmodule Lexin.Definition.Lang do
 
   @type t :: %__MODULE__{
           meaning: String.t() | nil,
+          usage: String.t() | nil,
           graminfo: String.t() | nil,
           comment: String.t() | nil,
           translation: String.t() | nil,

--- a/lib/lexin_web/live/components/card_component.html.heex
+++ b/lib/lexin_web/live/components/card_component.html.heex
@@ -31,6 +31,12 @@
       </div>
     <% end %>
 
+    <%= if @dfn.base.usage do %>
+      <div>
+        <%= gettext("Usage: %{usage}", usage: @dfn.base.usage) %>
+      </div>
+    <% end %>
+
     <%= if @dfn.target.translation do %>
       <div class="serp_translation">
         <%= @dfn.target.translation %>

--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,8 @@ defmodule Lexin.MixProject do
   defp aliases do
     [
       setup: ["deps.get"],
-      "assets.deploy": ["esbuild default --minify", "phx.digest"]
+      "assets.deploy": ["esbuild default --minify", "phx.digest"],
+      "gettext.update": ["gettext.extract --merge --no-fuzzy"]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.6.6",
+      version: "0.6.7",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:gettext] ++ Mix.compilers(),

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -16,146 +16,151 @@ msgid "listen"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:24
+#: lib/lexin_web/live/components/card_component.html.heex:30
 msgid "Alternate: %{alt}"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:39
+#: lib/lexin_web/live/components/card_component.html.heex:36
+msgid "Usage: %{usage}"
+msgstr ""
+
+#, elixir-format
+#: lib/lexin_web/live/components/card_component.html.heex:55
 msgid "Antonyms: %{antonyms}"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:47
+#: lib/lexin_web/live/components/card_component.html.heex:63
 msgid "Examples"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:63
+#: lib/lexin_web/live/components/card_component.html.heex:79
 msgid "Idioms"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:79
+#: lib/lexin_web/live/components/card_component.html.heex:95
 msgid "Compounds"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:95
+#: lib/lexin_web/live/components/card_component.html.heex:111
 msgid "Extra"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.html.heex:18
+#: lib/lexin_web/live/components/search_form_component.html.heex:20
 msgid "Search"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:59
+#: lib/lexin_web/live/components/search_form_component.ex:66
 msgid "Select language"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:32
+#: lib/lexin_web/live/components/search_form_component.ex:39
 msgid "albanian"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:33
+#: lib/lexin_web/live/components/search_form_component.ex:40
 msgid "amharic"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:34
+#: lib/lexin_web/live/components/search_form_component.ex:41
 msgid "arabic"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:35
+#: lib/lexin_web/live/components/search_form_component.ex:42
 msgid "azerbaijani"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:36
+#: lib/lexin_web/live/components/search_form_component.ex:43
 msgid "bosnian"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:37
+#: lib/lexin_web/live/components/search_form_component.ex:44
 msgid "english"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:38
+#: lib/lexin_web/live/components/search_form_component.ex:45
 msgid "finnish"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:39
+#: lib/lexin_web/live/components/search_form_component.ex:46
 msgid "greek"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:40
+#: lib/lexin_web/live/components/search_form_component.ex:47
 msgid "croatian"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:41
+#: lib/lexin_web/live/components/search_form_component.ex:48
 msgid "northern_kurdish"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:42
+#: lib/lexin_web/live/components/search_form_component.ex:49
 msgid "pashto"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:43
+#: lib/lexin_web/live/components/search_form_component.ex:50
 msgid "persian"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:44
+#: lib/lexin_web/live/components/search_form_component.ex:51
 msgid "russian"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:45
+#: lib/lexin_web/live/components/search_form_component.ex:52
 msgid "serbian_latin"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:46
+#: lib/lexin_web/live/components/search_form_component.ex:53
 msgid "serbian_cyrillic"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:47
+#: lib/lexin_web/live/components/search_form_component.ex:54
 msgid "somali"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:48
+#: lib/lexin_web/live/components/search_form_component.ex:55
 msgid "spanish"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:49
+#: lib/lexin_web/live/components/search_form_component.ex:56
 msgid "swedish"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:50
+#: lib/lexin_web/live/components/search_form_component.ex:57
 msgid "southern_kurdish"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:51
+#: lib/lexin_web/live/components/search_form_component.ex:58
 msgid "tigrinya"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:52
+#: lib/lexin_web/live/components/search_form_component.ex:59
 msgid "turkish"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -17,146 +17,151 @@ msgid "listen"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:24
+#: lib/lexin_web/live/components/card_component.html.heex:30
 msgid "Alternate: %{alt}"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:39
+#: lib/lexin_web/live/components/card_component.html.heex:36
+msgid "Usage: %{usage}"
+msgstr ""
+
+#, elixir-format
+#: lib/lexin_web/live/components/card_component.html.heex:55
 msgid "Antonyms: %{antonyms}"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:47
+#: lib/lexin_web/live/components/card_component.html.heex:63
 msgid "Examples"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:63
+#: lib/lexin_web/live/components/card_component.html.heex:79
 msgid "Idioms"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:79
+#: lib/lexin_web/live/components/card_component.html.heex:95
 msgid "Compounds"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:95
+#: lib/lexin_web/live/components/card_component.html.heex:111
 msgid "Extra"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.html.heex:18
+#: lib/lexin_web/live/components/search_form_component.html.heex:20
 msgid "Search"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:59
+#: lib/lexin_web/live/components/search_form_component.ex:66
 msgid "Select language"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:32
+#: lib/lexin_web/live/components/search_form_component.ex:39
 msgid "albanian"
 msgstr "Albanian"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:33
+#: lib/lexin_web/live/components/search_form_component.ex:40
 msgid "amharic"
 msgstr "Amharic"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:34
+#: lib/lexin_web/live/components/search_form_component.ex:41
 msgid "arabic"
 msgstr "Arabic"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:35
+#: lib/lexin_web/live/components/search_form_component.ex:42
 msgid "azerbaijani"
 msgstr "Azerbaijani"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:36
+#: lib/lexin_web/live/components/search_form_component.ex:43
 msgid "bosnian"
 msgstr "Bosnian"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:37
+#: lib/lexin_web/live/components/search_form_component.ex:44
 msgid "english"
 msgstr "English"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:38
+#: lib/lexin_web/live/components/search_form_component.ex:45
 msgid "finnish"
 msgstr "Finnish"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:39
+#: lib/lexin_web/live/components/search_form_component.ex:46
 msgid "greek"
 msgstr "Greek"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:40
+#: lib/lexin_web/live/components/search_form_component.ex:47
 msgid "croatian"
 msgstr "Croatian"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:41
+#: lib/lexin_web/live/components/search_form_component.ex:48
 msgid "northern_kurdish"
 msgstr "Northern Kurdish"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:42
+#: lib/lexin_web/live/components/search_form_component.ex:49
 msgid "pashto"
 msgstr "Pashto"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:43
+#: lib/lexin_web/live/components/search_form_component.ex:50
 msgid "persian"
 msgstr "Persian"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:44
+#: lib/lexin_web/live/components/search_form_component.ex:51
 msgid "russian"
 msgstr "Russian"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:45
+#: lib/lexin_web/live/components/search_form_component.ex:52
 msgid "serbian_latin"
 msgstr "Serbian (Latin)"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:46
+#: lib/lexin_web/live/components/search_form_component.ex:53
 msgid "serbian_cyrillic"
 msgstr "Serbian (Cyrillic)"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:47
+#: lib/lexin_web/live/components/search_form_component.ex:54
 msgid "somali"
 msgstr "Somali"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:48
+#: lib/lexin_web/live/components/search_form_component.ex:55
 msgid "spanish"
 msgstr "Spanish"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:49
+#: lib/lexin_web/live/components/search_form_component.ex:56
 msgid "swedish"
 msgstr "Swedish"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:50
+#: lib/lexin_web/live/components/search_form_component.ex:57
 msgid "southern_kurdish"
 msgstr "Southern Kurdish"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:51
+#: lib/lexin_web/live/components/search_form_component.ex:58
 msgid "tigrinya"
 msgstr "Tigrinya"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:52
+#: lib/lexin_web/live/components/search_form_component.ex:59
 msgid "turkish"
 msgstr "Turkish"

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -11,21 +11,21 @@ msgstr ""
 "Language: en\n"
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:68
+#: lib/lexin_web/live/dictionary_live.ex:74
 msgid "Not found"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:71
+#: lib/lexin_web/live/dictionary_live.ex:77
 msgid "Exception processing search request"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:77
+#: lib/lexin_web/live/dictionary_live.ex:83
 msgid "Unknown (yet) error – fun for developers"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:74
+#: lib/lexin_web/live/dictionary_live.ex:80
 msgid "Language is not supported"
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -1,19 +1,19 @@
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:68
+#: lib/lexin_web/live/dictionary_live.ex:74
 msgid "Not found"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:71
+#: lib/lexin_web/live/dictionary_live.ex:77
 msgid "Exception processing search request"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:77
+#: lib/lexin_web/live/dictionary_live.ex:83
 msgid "Unknown (yet) error – fun for developers"
 msgstr ""
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:74
+#: lib/lexin_web/live/dictionary_live.ex:80
 msgid "Language is not supported"
 msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -17,146 +17,151 @@ msgid "listen"
 msgstr "слушать"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:24
+#: lib/lexin_web/live/components/card_component.html.heex:30
 msgid "Alternate: %{alt}"
 msgstr "Альтернатива: %{alt}"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:39
+#: lib/lexin_web/live/components/card_component.html.heex:36
+msgid "Usage: %{usage}"
+msgstr "Использование: %{usage}"
+
+#, elixir-format
+#: lib/lexin_web/live/components/card_component.html.heex:55
 msgid "Antonyms: %{antonyms}"
 msgstr "Антонимы: %{antonyms}"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:47
+#: lib/lexin_web/live/components/card_component.html.heex:63
 msgid "Examples"
 msgstr "Примеры"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:63
+#: lib/lexin_web/live/components/card_component.html.heex:79
 msgid "Idioms"
 msgstr "Идиомы"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:79
+#: lib/lexin_web/live/components/card_component.html.heex:95
 msgid "Compounds"
 msgstr "Составные слова"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:95
+#: lib/lexin_web/live/components/card_component.html.heex:111
 msgid "Extra"
 msgstr "Дополнительно"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.html.heex:18
+#: lib/lexin_web/live/components/search_form_component.html.heex:20
 msgid "Search"
 msgstr "Искать"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:59
+#: lib/lexin_web/live/components/search_form_component.ex:66
 msgid "Select language"
 msgstr "Выберите язык"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:32
+#: lib/lexin_web/live/components/search_form_component.ex:39
 msgid "albanian"
 msgstr "Албанский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:33
+#: lib/lexin_web/live/components/search_form_component.ex:40
 msgid "amharic"
 msgstr "Амхарский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:34
+#: lib/lexin_web/live/components/search_form_component.ex:41
 msgid "arabic"
 msgstr "Арабский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:35
+#: lib/lexin_web/live/components/search_form_component.ex:42
 msgid "azerbaijani"
 msgstr "Азербайджанский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:36
+#: lib/lexin_web/live/components/search_form_component.ex:43
 msgid "bosnian"
 msgstr "Боснийский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:37
+#: lib/lexin_web/live/components/search_form_component.ex:44
 msgid "english"
 msgstr "Английский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:38
+#: lib/lexin_web/live/components/search_form_component.ex:45
 msgid "finnish"
 msgstr "Финский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:39
+#: lib/lexin_web/live/components/search_form_component.ex:46
 msgid "greek"
 msgstr "Греческий"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:40
+#: lib/lexin_web/live/components/search_form_component.ex:47
 msgid "croatian"
 msgstr "Хорватский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:41
+#: lib/lexin_web/live/components/search_form_component.ex:48
 msgid "northern_kurdish"
 msgstr "Севернокурдский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:42
+#: lib/lexin_web/live/components/search_form_component.ex:49
 msgid "pashto"
 msgstr "Пушту"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:43
+#: lib/lexin_web/live/components/search_form_component.ex:50
 msgid "persian"
 msgstr "Персидский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:44
+#: lib/lexin_web/live/components/search_form_component.ex:51
 msgid "russian"
 msgstr "Русский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:45
+#: lib/lexin_web/live/components/search_form_component.ex:52
 msgid "serbian_latin"
 msgstr "Сербский (латиница)"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:46
+#: lib/lexin_web/live/components/search_form_component.ex:53
 msgid "serbian_cyrillic"
 msgstr "Сербский (кириллица)"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:47
+#: lib/lexin_web/live/components/search_form_component.ex:54
 msgid "somali"
 msgstr "Сомалийский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:48
+#: lib/lexin_web/live/components/search_form_component.ex:55
 msgid "spanish"
 msgstr "Испанский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:49
+#: lib/lexin_web/live/components/search_form_component.ex:56
 msgid "swedish"
 msgstr "Шведский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:50
+#: lib/lexin_web/live/components/search_form_component.ex:57
 msgid "southern_kurdish"
 msgstr "Южнокурдский"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:51
+#: lib/lexin_web/live/components/search_form_component.ex:58
 msgid "tigrinya"
 msgstr "Тигринья"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:52
+#: lib/lexin_web/live/components/search_form_component.ex:59
 msgid "turkish"
 msgstr "Турецкий"

--- a/priv/gettext/ru/LC_MESSAGES/errors.po
+++ b/priv/gettext/ru/LC_MESSAGES/errors.po
@@ -12,21 +12,21 @@ msgstr ""
 "Plural-Forms: nplurals=3\n"
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:68
+#: lib/lexin_web/live/dictionary_live.ex:74
 msgid "Not found"
 msgstr "Не найдено"
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:71
+#: lib/lexin_web/live/dictionary_live.ex:77
 msgid "Exception processing search request"
 msgstr "Ошибка при обработке запроса"
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:77
+#: lib/lexin_web/live/dictionary_live.ex:83
 msgid "Unknown (yet) error – fun for developers"
 msgstr "Неизвестная (пока) ошибка – задачка для разработчиков"
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:74
+#: lib/lexin_web/live/dictionary_live.ex:80
 msgid "Language is not supported"
 msgstr "Выбранный язык не поддерживается"

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -17,146 +17,152 @@ msgid "listen"
 msgstr "lyssna"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:24
+#: lib/lexin_web/live/components/card_component.html.heex:30
 msgid "Alternate: %{alt}"
 msgstr "Variantform: %{alt}"
 
+
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:39
+#: lib/lexin_web/live/components/card_component.html.heex:36
+msgid "Usage: %{usage}"
+msgstr "Användning: %{usage}"
+
+#, elixir-format
+#: lib/lexin_web/live/components/card_component.html.heex:55
 msgid "Antonyms: %{antonyms}"
 msgstr "Motsatser: %{antonyms}"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:47
+#: lib/lexin_web/live/components/card_component.html.heex:63
 msgid "Examples"
 msgstr "Exempel"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:63
+#: lib/lexin_web/live/components/card_component.html.heex:79
 msgid "Idioms"
 msgstr "Uttryck"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:79
+#: lib/lexin_web/live/components/card_component.html.heex:95
 msgid "Compounds"
 msgstr "Sammansättningar"
 
 #, elixir-format
-#: lib/lexin_web/live/components/card_component.html.heex:95
+#: lib/lexin_web/live/components/card_component.html.heex:111
 msgid "Extra"
 msgstr "Extra"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.html.heex:18
+#: lib/lexin_web/live/components/search_form_component.html.heex:20
 msgid "Search"
 msgstr "Sök"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:59
+#: lib/lexin_web/live/components/search_form_component.ex:66
 msgid "Select language"
 msgstr "Välj språk"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:32
+#: lib/lexin_web/live/components/search_form_component.ex:39
 msgid "albanian"
 msgstr "Albanska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:33
+#: lib/lexin_web/live/components/search_form_component.ex:40
 msgid "amharic"
 msgstr "Amhariska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:34
+#: lib/lexin_web/live/components/search_form_component.ex:41
 msgid "arabic"
 msgstr "Arabiska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:35
+#: lib/lexin_web/live/components/search_form_component.ex:42
 msgid "azerbaijani"
 msgstr "Azerbajdzjanska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:36
+#: lib/lexin_web/live/components/search_form_component.ex:43
 msgid "bosnian"
 msgstr "Bosniska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:37
+#: lib/lexin_web/live/components/search_form_component.ex:44
 msgid "english"
 msgstr "Engelska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:38
+#: lib/lexin_web/live/components/search_form_component.ex:45
 msgid "finnish"
 msgstr "Finska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:39
+#: lib/lexin_web/live/components/search_form_component.ex:46
 msgid "greek"
 msgstr "Grekiska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:40
+#: lib/lexin_web/live/components/search_form_component.ex:47
 msgid "croatian"
 msgstr "Kroatiska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:41
+#: lib/lexin_web/live/components/search_form_component.ex:48
 msgid "northern_kurdish"
 msgstr "Nordkurdiska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:42
+#: lib/lexin_web/live/components/search_form_component.ex:49
 msgid "pashto"
 msgstr "Pashto"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:43
+#: lib/lexin_web/live/components/search_form_component.ex:50
 msgid "persian"
 msgstr "Persiska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:44
+#: lib/lexin_web/live/components/search_form_component.ex:51
 msgid "russian"
 msgstr "Ryska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:45
+#: lib/lexin_web/live/components/search_form_component.ex:52
 msgid "serbian_latin"
 msgstr "Serbiska (latinskt)"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:46
+#: lib/lexin_web/live/components/search_form_component.ex:53
 msgid "serbian_cyrillic"
 msgstr "Serbiska (kirilliskt)"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:47
+#: lib/lexin_web/live/components/search_form_component.ex:54
 msgid "somali"
 msgstr "Somaliska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:48
+#: lib/lexin_web/live/components/search_form_component.ex:55
 msgid "spanish"
 msgstr "Spanska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:49
+#: lib/lexin_web/live/components/search_form_component.ex:56
 msgid "swedish"
 msgstr "Svenska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:50
+#: lib/lexin_web/live/components/search_form_component.ex:57
 msgid "southern_kurdish"
 msgstr "Sydkurdiska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:51
+#: lib/lexin_web/live/components/search_form_component.ex:58
 msgid "tigrinya"
 msgstr "Tigrinska"
 
 #, elixir-format
-#: lib/lexin_web/live/components/search_form_component.ex:52
+#: lib/lexin_web/live/components/search_form_component.ex:59
 msgid "turkish"
 msgstr "Turkiska"

--- a/priv/gettext/sv/LC_MESSAGES/errors.po
+++ b/priv/gettext/sv/LC_MESSAGES/errors.po
@@ -12,21 +12,21 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:68
+#: lib/lexin_web/live/dictionary_live.ex:74
 msgid "Not found"
 msgstr "Hittades inte"
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:71
+#: lib/lexin_web/live/dictionary_live.ex:77
 msgid "Exception processing search request"
 msgstr "Undantag bearbetar sökförfrågan"
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:77
+#: lib/lexin_web/live/dictionary_live.ex:83
 msgid "Unknown (yet) error – fun for developers"
 msgstr "Okänt (ännu) fel – kul för utvecklare"
 
 #, elixir-format
-#: lib/lexin_web/live/dictionary_live.ex:74
+#: lib/lexin_web/live/dictionary_live.ex:80
 msgid "Language is not supported"
 msgstr "Språk stöds inte"


### PR DESCRIPTION
### Case-insensitive Search

Search was case-sensitive in some cases: while it works fine for English-like words, the case of the query affects queries in Russian. For example, "человек" gave the results, while "Человек" was empty.

Maybe SQLite is case-sensitive for non-ASCII characters.

### Add "Usage" to Parser

Also, users noticed lack of some more information in the Lexin Light output (in comparison to original Lexin service). It was `<Usage/>` from the XML files.

Here, we add this field to the parser and show it to the end users. There is a new translation added for new label in the output.

This fixes #13.

P.S. We added a mini-task to the `mix.exs` just to remember how to update all gettext files with one command (it parses all source code and does corresponding updates to the translation files – see in the commit).