### PR TITLE
Fixes and Refactoring

### DIFF
--- a/lib/lexin_web/live/components/search_form_component.html.heex
+++ b/lib/lexin_web/live/components/search_form_component.html.heex
@@ -1,4 +1,4 @@
-<form id="search_form" phx-target={@myself} phx-change="suggest" phx-submit="submit" phx-hook="saveLanguage">
+<form id={@id} phx-target={@myself} phx-submit="submit" phx-hook="saveLanguage">
   <div id="form_header">
     <div class="logo">
       <a href="/" class="logo-wrapper">
@@ -19,7 +19,7 @@
       <input
         id="form-query_field" class={klass} type="text" name="query" value={@query}
         autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" autofocus
-        phx-target={@myself} phx-focus="query-focus"
+        phx-target={@myself} phx-debounce="300" phx-change="suggest" phx-focus="query-focus"
       />
 
       <%= if has_suggestions?(@in_focus, @suggestions) do %>

--- a/lib/lexin_web/live/dictionary_live.html.heex
+++ b/lib/lexin_web/live/dictionary_live.html.heex
@@ -1,4 +1,4 @@
-<%= live_component(SearchFormComponent, id: :form, lang: @lang, query: @query, suggestions: @suggestions, in_focus: @in_focus) %>
+<%= live_component(SearchFormComponent, id: "search_form", lang: @lang, query: @query, suggestions: @suggestions, in_focus: @in_focus) %>
 
 <p class="alert alert-info" role="alert"
   phx-click="lv:clear-flash"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.7.3",
+      version: "0.7.4",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -10,157 +10,157 @@
 msgid ""
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:8
+#, elixir-autogen, elixir-format
 msgid "listen"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:30
+#, elixir-autogen, elixir-format
 msgid "Alternate: %{alt}"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:36
+#, elixir-autogen, elixir-format
 msgid "Usage: %{usage}"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:55
+#, elixir-autogen, elixir-format
 msgid "Antonyms: %{antonyms}"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:63
+#, elixir-autogen, elixir-format
 msgid "Examples"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:79
+#, elixir-autogen, elixir-format
 msgid "Idioms"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:95
+#, elixir-autogen, elixir-format
 msgid "Compounds"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:111
+#, elixir-autogen, elixir-format
 msgid "Extra"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.html.heex:36
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:89
+#, elixir-autogen, elixir-format
 msgid "Select language"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:62
+#, elixir-autogen, elixir-format
 msgid "albanian"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:63
+#, elixir-autogen, elixir-format
 msgid "amharic"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:64
+#, elixir-autogen, elixir-format
 msgid "arabic"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:65
+#, elixir-autogen, elixir-format
 msgid "azerbaijani"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:66
+#, elixir-autogen, elixir-format
 msgid "bosnian"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:67
+#, elixir-autogen, elixir-format
 msgid "english"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:68
+#, elixir-autogen, elixir-format
 msgid "finnish"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:69
+#, elixir-autogen, elixir-format
 msgid "greek"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:70
+#, elixir-autogen, elixir-format
 msgid "croatian"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:71
+#, elixir-autogen, elixir-format
 msgid "northern_kurdish"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:72
+#, elixir-autogen, elixir-format
 msgid "pashto"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:73
+#, elixir-autogen, elixir-format
 msgid "persian"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:74
+#, elixir-autogen, elixir-format
 msgid "russian"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:75
+#, elixir-autogen, elixir-format
 msgid "serbian_latin"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:76
+#, elixir-autogen, elixir-format
 msgid "serbian_cyrillic"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:77
+#, elixir-autogen, elixir-format
 msgid "somali"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:78
+#, elixir-autogen, elixir-format
 msgid "spanish"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:79
+#, elixir-autogen, elixir-format
 msgid "swedish"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:80
+#, elixir-autogen, elixir-format
 msgid "southern_kurdish"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:81
+#, elixir-autogen, elixir-format
 msgid "tigrinya"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:82
+#, elixir-autogen, elixir-format
 msgid "turkish"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,157 +11,157 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:8
+#, elixir-autogen, elixir-format
 msgid "listen"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:30
+#, elixir-autogen, elixir-format
 msgid "Alternate: %{alt}"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:36
+#, elixir-autogen, elixir-format
 msgid "Usage: %{usage}"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:55
+#, elixir-autogen, elixir-format
 msgid "Antonyms: %{antonyms}"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:63
+#, elixir-autogen, elixir-format
 msgid "Examples"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:79
+#, elixir-autogen, elixir-format
 msgid "Idioms"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:95
+#, elixir-autogen, elixir-format
 msgid "Compounds"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:111
+#, elixir-autogen, elixir-format
 msgid "Extra"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.html.heex:36
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:89
+#, elixir-autogen, elixir-format
 msgid "Select language"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:62
+#, elixir-autogen, elixir-format
 msgid "albanian"
 msgstr "Albanian"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:63
+#, elixir-autogen, elixir-format
 msgid "amharic"
 msgstr "Amharic"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:64
+#, elixir-autogen, elixir-format
 msgid "arabic"
 msgstr "Arabic"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:65
+#, elixir-autogen, elixir-format
 msgid "azerbaijani"
 msgstr "Azerbaijani"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:66
+#, elixir-autogen, elixir-format
 msgid "bosnian"
 msgstr "Bosnian"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:67
+#, elixir-autogen, elixir-format
 msgid "english"
 msgstr "English"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:68
+#, elixir-autogen, elixir-format
 msgid "finnish"
 msgstr "Finnish"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:69
+#, elixir-autogen, elixir-format
 msgid "greek"
 msgstr "Greek"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:70
+#, elixir-autogen, elixir-format
 msgid "croatian"
 msgstr "Croatian"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:71
+#, elixir-autogen, elixir-format
 msgid "northern_kurdish"
 msgstr "Northern Kurdish"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:72
+#, elixir-autogen, elixir-format
 msgid "pashto"
 msgstr "Pashto"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:73
+#, elixir-autogen, elixir-format
 msgid "persian"
 msgstr "Persian"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:74
+#, elixir-autogen, elixir-format
 msgid "russian"
 msgstr "Russian"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:75
+#, elixir-autogen, elixir-format
 msgid "serbian_latin"
 msgstr "Serbian (Latin)"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:76
+#, elixir-autogen, elixir-format
 msgid "serbian_cyrillic"
 msgstr "Serbian (Cyrillic)"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:77
+#, elixir-autogen, elixir-format
 msgid "somali"
 msgstr "Somali"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:78
+#, elixir-autogen, elixir-format
 msgid "spanish"
 msgstr "Spanish"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:79
+#, elixir-autogen, elixir-format
 msgid "swedish"
 msgstr "Swedish"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:80
+#, elixir-autogen, elixir-format
 msgid "southern_kurdish"
 msgstr "Southern Kurdish"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:81
+#, elixir-autogen, elixir-format
 msgid "tigrinya"
 msgstr "Tigrinya"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:82
+#, elixir-autogen, elixir-format
 msgid "turkish"
 msgstr "Turkish"

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -10,22 +10,22 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:83
+#, elixir-autogen, elixir-format
 msgid "Not found"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:86
+#, elixir-autogen, elixir-format
 msgid "Exception processing search request"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:92
+#, elixir-autogen, elixir-format
 msgid "Unknown (yet) error – fun for developers"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:89
+#, elixir-autogen, elixir-format
 msgid "Language is not supported"
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -1,19 +1,19 @@
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:83
+#, elixir-autogen, elixir-format
 msgid "Not found"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:86
+#, elixir-autogen, elixir-format
 msgid "Exception processing search request"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:92
+#, elixir-autogen, elixir-format
 msgid "Unknown (yet) error – fun for developers"
 msgstr ""
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:89
+#, elixir-autogen, elixir-format
 msgid "Language is not supported"
 msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -11,157 +11,157 @@ msgstr ""
 "Language: ru\n"
 "Plural-Forms: nplurals=3\n"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:8
+#, elixir-autogen, elixir-format
 msgid "listen"
 msgstr "слушать"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:30
+#, elixir-autogen, elixir-format
 msgid "Alternate: %{alt}"
 msgstr "Альтернатива: %{alt}"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:36
+#, elixir-autogen, elixir-format
 msgid "Usage: %{usage}"
 msgstr "Использование: %{usage}"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:55
+#, elixir-autogen, elixir-format
 msgid "Antonyms: %{antonyms}"
 msgstr "Антонимы: %{antonyms}"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:63
+#, elixir-autogen, elixir-format
 msgid "Examples"
 msgstr "Примеры"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:79
+#, elixir-autogen, elixir-format
 msgid "Idioms"
 msgstr "Идиомы"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:95
+#, elixir-autogen, elixir-format
 msgid "Compounds"
 msgstr "Составные слова"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:111
+#, elixir-autogen, elixir-format
 msgid "Extra"
 msgstr "Дополнительно"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.html.heex:36
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Искать"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:89
+#, elixir-autogen, elixir-format
 msgid "Select language"
 msgstr "Выберите язык"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:62
+#, elixir-autogen, elixir-format
 msgid "albanian"
 msgstr "Албанский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:63
+#, elixir-autogen, elixir-format
 msgid "amharic"
 msgstr "Амхарский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:64
+#, elixir-autogen, elixir-format
 msgid "arabic"
 msgstr "Арабский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:65
+#, elixir-autogen, elixir-format
 msgid "azerbaijani"
 msgstr "Азербайджанский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:66
+#, elixir-autogen, elixir-format
 msgid "bosnian"
 msgstr "Боснийский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:67
+#, elixir-autogen, elixir-format
 msgid "english"
 msgstr "Английский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:68
+#, elixir-autogen, elixir-format
 msgid "finnish"
 msgstr "Финский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:69
+#, elixir-autogen, elixir-format
 msgid "greek"
 msgstr "Греческий"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:70
+#, elixir-autogen, elixir-format
 msgid "croatian"
 msgstr "Хорватский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:71
+#, elixir-autogen, elixir-format
 msgid "northern_kurdish"
 msgstr "Севернокурдский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:72
+#, elixir-autogen, elixir-format
 msgid "pashto"
 msgstr "Пушту"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:73
+#, elixir-autogen, elixir-format
 msgid "persian"
 msgstr "Персидский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:74
+#, elixir-autogen, elixir-format
 msgid "russian"
 msgstr "Русский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:75
+#, elixir-autogen, elixir-format
 msgid "serbian_latin"
 msgstr "Сербский (латиница)"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:76
+#, elixir-autogen, elixir-format
 msgid "serbian_cyrillic"
 msgstr "Сербский (кириллица)"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:77
+#, elixir-autogen, elixir-format
 msgid "somali"
 msgstr "Сомалийский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:78
+#, elixir-autogen, elixir-format
 msgid "spanish"
 msgstr "Испанский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:79
+#, elixir-autogen, elixir-format
 msgid "swedish"
 msgstr "Шведский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:80
+#, elixir-autogen, elixir-format
 msgid "southern_kurdish"
 msgstr "Южнокурдский"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:81
+#, elixir-autogen, elixir-format
 msgid "tigrinya"
 msgstr "Тигринья"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:82
+#, elixir-autogen, elixir-format
 msgid "turkish"
 msgstr "Турецкий"

--- a/priv/gettext/ru/LC_MESSAGES/errors.po
+++ b/priv/gettext/ru/LC_MESSAGES/errors.po
@@ -11,22 +11,22 @@ msgstr ""
 "Language: ru\n"
 "Plural-Forms: nplurals=3\n"
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:83
+#, elixir-autogen, elixir-format
 msgid "Not found"
 msgstr "Не найдено"
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:86
+#, elixir-autogen, elixir-format
 msgid "Exception processing search request"
 msgstr "Ошибка при обработке запроса"
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:92
+#, elixir-autogen, elixir-format
 msgid "Unknown (yet) error – fun for developers"
 msgstr "Неизвестная (пока) ошибка – задачка для разработчиков"
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:89
+#, elixir-autogen, elixir-format
 msgid "Language is not supported"
 msgstr "Выбранный язык не поддерживается"

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -11,157 +11,157 @@ msgstr ""
 "Language: sv\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:8
+#, elixir-autogen, elixir-format
 msgid "listen"
 msgstr "lyssna"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:30
+#, elixir-autogen, elixir-format
 msgid "Alternate: %{alt}"
 msgstr "Variantform: %{alt}"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:36
+#, elixir-autogen, elixir-format
 msgid "Usage: %{usage}"
 msgstr "Användning: %{usage}"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:55
+#, elixir-autogen, elixir-format
 msgid "Antonyms: %{antonyms}"
 msgstr "Motsatser: %{antonyms}"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:63
+#, elixir-autogen, elixir-format
 msgid "Examples"
 msgstr "Exempel"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:79
+#, elixir-autogen, elixir-format
 msgid "Idioms"
 msgstr "Uttryck"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:95
+#, elixir-autogen, elixir-format
 msgid "Compounds"
 msgstr "Sammansättningar"
 
-#, elixir-format
 #: lib/lexin_web/live/components/card_component.html.heex:111
+#, elixir-autogen, elixir-format
 msgid "Extra"
 msgstr "Extra"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.html.heex:36
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Sök"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:89
+#, elixir-autogen, elixir-format
 msgid "Select language"
 msgstr "Välj språk"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:62
+#, elixir-autogen, elixir-format
 msgid "albanian"
 msgstr "Albanska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:63
+#, elixir-autogen, elixir-format
 msgid "amharic"
 msgstr "Amhariska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:64
+#, elixir-autogen, elixir-format
 msgid "arabic"
 msgstr "Arabiska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:65
+#, elixir-autogen, elixir-format
 msgid "azerbaijani"
 msgstr "Azerbajdzjanska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:66
+#, elixir-autogen, elixir-format
 msgid "bosnian"
 msgstr "Bosniska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:67
+#, elixir-autogen, elixir-format
 msgid "english"
 msgstr "Engelska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:68
+#, elixir-autogen, elixir-format
 msgid "finnish"
 msgstr "Finska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:69
+#, elixir-autogen, elixir-format
 msgid "greek"
 msgstr "Grekiska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:70
+#, elixir-autogen, elixir-format
 msgid "croatian"
 msgstr "Kroatiska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:71
+#, elixir-autogen, elixir-format
 msgid "northern_kurdish"
 msgstr "Nordkurdiska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:72
+#, elixir-autogen, elixir-format
 msgid "pashto"
 msgstr "Pashto"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:73
+#, elixir-autogen, elixir-format
 msgid "persian"
 msgstr "Persiska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:74
+#, elixir-autogen, elixir-format
 msgid "russian"
 msgstr "Ryska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:75
+#, elixir-autogen, elixir-format
 msgid "serbian_latin"
 msgstr "Serbiska (latinskt)"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:76
+#, elixir-autogen, elixir-format
 msgid "serbian_cyrillic"
 msgstr "Serbiska (kirilliskt)"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:77
+#, elixir-autogen, elixir-format
 msgid "somali"
 msgstr "Somaliska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:78
+#, elixir-autogen, elixir-format
 msgid "spanish"
 msgstr "Spanska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:79
+#, elixir-autogen, elixir-format
 msgid "swedish"
 msgstr "Svenska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:80
+#, elixir-autogen, elixir-format
 msgid "southern_kurdish"
 msgstr "Sydkurdiska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:81
+#, elixir-autogen, elixir-format
 msgid "tigrinya"
 msgstr "Tigrinska"
 
-#, elixir-format
 #: lib/lexin_web/live/components/search_form_component.ex:82
+#, elixir-autogen, elixir-format
 msgid "turkish"
 msgstr "Turkiska"

--- a/priv/gettext/sv/LC_MESSAGES/errors.po
+++ b/priv/gettext/sv/LC_MESSAGES/errors.po
@@ -11,22 +11,22 @@ msgstr ""
 "Language: sv\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:83
+#, elixir-autogen, elixir-format
 msgid "Not found"
 msgstr "Hittades inte"
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:86
+#, elixir-autogen, elixir-format
 msgid "Exception processing search request"
 msgstr "Undantag bearbetar sökförfrågan"
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:92
+#, elixir-autogen, elixir-format
 msgid "Unknown (yet) error – fun for developers"
 msgstr "Okänt (ännu) fel – kul för utvecklare"
 
-#, elixir-format
 #: lib/lexin_web/live/dictionary_live.ex:89
+#, elixir-autogen, elixir-format
 msgid "Language is not supported"
 msgstr "Språk stöds inte"


### PR DESCRIPTION
## Reconnection Issue

We noticed that when reconnection happens, the user gets into an endless loading loop. This can happen, for example, when a laptop went to sleep, you wake it up, and the websocket on the Lexin page reconnects to the server.

In the logs, we noticed that front-end was always trying to send `suggest` event with only `lang` (and `_target` as meta) value. We do not have `handle_event` for this case, and our backend always got crashed.

At first, we didn't get _why_ front-end even sends this `suggest` event.

After investigation, we found that it's a normal LiveView behavior, and it attempts to send `phx-change` event in case of crash or reconnection, read more: https://hexdocs.pm/phoenix_live_view/form-bindings.html#recovery-following-crashes-or-disconnects

We fixed it by moving `phx-change` attribute exactly to the `input` field from the `form` itself. Which is logically correct for us – we want to show suggestions only when user changes the query.

P.S. We have also returned `phx-debounce` setting for the suggestion delay. It was accidentally removed recently.

P.P.S. Though, as we also noticed that with the `phx-change` event re-conciliation we were receiving not all the fields of the form, but only `select` one (which does have its own `phx-change` handler configured). This might be the bug, but it is going to be handled separately.

## `SearchFormComponent.find_suggestions`

We want to simplify it and avoid giving it the whole `socket` structure, so we extract `lang` and `query` parameters in the event handler and made `find_suggestions` simple and straightforward.

We also added a special case when user not yet selected the language they want to translate to.