### PR TITLE
Rename from Light to Mobi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Lexin Light
+# Lexin Mobi
 
-It's a small web application for Swedish dictionary.
+It's a small web and mobile application for Swedish dictionary.
 
 ## Intro
 
-Lexin Light provides a new modern and responsive user interface to the [Lexin](http://lexin2.nada.kth.se/lexin/) dictionary service. You can find some [history notes](docs/HISTORY.md) about creation and first look of this application.
+Lexin Mobi provides a new modern and responsive user interface to the [Lexin](http://lexin2.nada.kth.se/lexin/) dictionary service. You can find some [history notes](docs/HISTORY.md) about creation and first look of this application.
 
-Lexin Light is written as [Progressive web apps (PWA)](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) and can be installed and used on mobile devices or on desktops.
+Lexin Mobi is written as [Progressive web apps (PWA)](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) and can be installed and used on mobile devices or on desktops.
 
 ### Screenshots
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Lexin Mobi is written as [Progressive web apps (PWA)](https://developer.mozilla.
 
 <table>
   <tr>
-    <td><img width="612" alt="image" src="https://user-images.githubusercontent.com/113878/188648480-ce8f18cd-b87a-4ca6-982d-36fb7c07d698.png"></td>
-    <td><img width="612" alt="image" src="https://user-images.githubusercontent.com/113878/188648585-135f6477-ec1d-4a15-9e36-9199e45ad547.png"></td>
+    <td><img width="612" alt="image" src="https://user-images.githubusercontent.com/113878/191539899-600a8de1-0dbd-4ca7-bd4d-0255a9cba87b.png"></td>
+    <td><img width="612" alt="image" src="https://user-images.githubusercontent.com/113878/191540072-1a82d451-7bda-4ea3-880d-5617dd04d1fe.png"></td>
   </tr>
 </table>
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -17,7 +17,7 @@ config :lexin, LexinWeb.Endpoint,
 config :logger, level: :info
 
 config :sentry,
-  dsn: "https://fa6ced7a5eae47d4b7caf43c6ca22304@o1110717.ingest.sentry.io/6139845",
+  dsn: "https://50f9d0381b9548828d7143ad0dd9ad7a@o1110717.ingest.sentry.io/6766507",
   environment_name: :prod,
   enable_source_code_context: true,
   root_source_code_path: File.cwd!(),

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,7 +10,7 @@ import Config
 # which you should run after static files are built and
 # before starting your production server.
 config :lexin, LexinWeb.Endpoint,
-  url: [host: "lexin.summercode.com", port: 4000],
+  url: [host: "lexin.mobi", port: 4000],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 # Do not print debug messages in production

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -21,3 +21,7 @@ In comparison to standard Lexin website interface:
 | Entry Screen | Search Results |
 |--------------|----------------|
 | ![image](https://user-images.githubusercontent.com/113878/134809705-6fe7f038-bafd-4a90-8a17-afa588504b35.png) | ![image](https://user-images.githubusercontent.com/113878/134809719-4292915f-b09a-4b79-a6d0-bbf8d9742896.png) |
+
+## Rename to Mobi
+
+We decided to change initial project name from "Lexin Light" to "Lexin Mobi" to align it with the short domain name we bought: https://lexin.mobi.

--- a/lib/lexin_web/live/components/search_form_component.html.heex
+++ b/lib/lexin_web/live/components/search_form_component.html.heex
@@ -3,7 +3,7 @@
     <div class="logo">
       <a href="/" class="logo-wrapper">
         <img class="logo-img" src={Routes.static_path(@socket, "/images/icon.svg")} />
-        <span class="logo-text">Light</span>
+        <span class="logo-text">Mobi</span>
       </a>
     </div>
 

--- a/lib/lexin_web/templates/layout/root.html.heex
+++ b/lib/lexin_web/templates/layout/root.html.heex
@@ -7,10 +7,10 @@
 
     <%= csrf_meta_tag() %>
 
-    <%= live_title_tag(assigns[:page_title] || "Lexin Light") %>
+    <%= live_title_tag(assigns[:page_title] || "Lexin Mobi") %>
     <meta
       name="description"
-      content="Lexin Light. Lexin är en kombination av lexikon och ordböcker som har tagits fram för användning i primärt invandrarundervisning. Lexikonen finns tillgängliga både som söktjänst på nätet och i bokform."
+      content="Lexin Mobi. Lexin är en kombination av lexikon och ordböcker som har tagits fram för användning i primärt invandrarundervisning. Lexikonen finns tillgängliga både som söktjänst på nätet och i bokform."
     />
 
     <link rel="icon" href={Routes.static_path(@conn, "/favicon.ico")} />
@@ -46,8 +46,8 @@
             <li><%= link("Install", to: Routes.pages_path(@conn, :install)) %></li>
           </ul>
 
-          <div class="footer-version" title={"Lexin Light #{app_version()}"}>
-            Lexin Light sponsored by <a
+          <div class="footer-version" title={"Lexin Mobi #{app_version()}"}>
+            Lexin Mobi sponsored by <a
               href="https://0x.se"
               title="Swedish technology consultancy company"
               target="_blank"

--- a/lib/lexin_web/templates/pages/about.html.heex
+++ b/lib/lexin_web/templates/pages/about.html.heex
@@ -1,7 +1,7 @@
 <div class="logo">
   <a href="/" class="logo-wrapper">
     &larr;&nbsp; <img class="logo-img" src={Routes.static_path(@conn, "/images/icon.svg")} />
-    <span class="logo-text">Light</span>
+    <span class="logo-text">Mobi</span>
   </a>
 </div>
 
@@ -9,15 +9,11 @@
   <h4>About</h4>
 
   <p>
-    Lexin Light is a new "face" for the well-known
-    <a href="https://lexin.nada.kth.se/lexin/" target="_blank" rel="noopener">Lexin</a>
-    (Swedish dictionary web service).
-  </p>
-
-  <p>
-    <cite>
-      “Lexin – ett samarbete mellan Institutet för språk och folkminnen och Kungliga tekniska högskolan.”
-    </cite>
+    Lexin Mobi is a new "face" for the known Swedish dictionary web service <a
+      href="https://lexin.nada.kth.se/lexin/"
+      target="_blank"
+      rel="noopener"
+    >Lexin</a>.
   </p>
 
   <p>

--- a/lib/lexin_web/templates/pages/contact.html.heex
+++ b/lib/lexin_web/templates/pages/contact.html.heex
@@ -1,7 +1,7 @@
 <div class="logo">
   <a href="/" class="logo-wrapper">
     &larr;&nbsp; <img class="logo-img" src={Routes.static_path(@conn, "/images/icon.svg")} />
-    <span class="logo-text">Light</span>
+    <span class="logo-text">Mobi</span>
   </a>
 </div>
 
@@ -9,7 +9,7 @@
   <h4>Contact</h4>
 
   <p>
-    Lexin Light is an open-source project, and you can find its code on <a
+    Lexin Mobi is an open-source project, and you can find its code on <a
       href="https://github.com/cr0t/lexin"
       rel="noopener"
       target="_blank"

--- a/lib/lexin_web/templates/pages/install.html.heex
+++ b/lib/lexin_web/templates/pages/install.html.heex
@@ -1,7 +1,7 @@
 <div class="logo">
   <a href="/" class="logo-wrapper">
     &larr;&nbsp; <img class="logo-img" src={Routes.static_path(@conn, "/images/icon.svg")} />
-    <span class="logo-text">Light</span>
+    <span class="logo-text">Mobi</span>
   </a>
 </div>
 
@@ -9,7 +9,7 @@
   <h4>Install</h4>
 
   <p>
-    You can use Lexin Light by opening it as a <a href="https://lexin.summercode.com/">website</a>
+    You can use Lexin Mobi by opening it as a <a href="https://lexin.mobi/">website</a>
     in your favorite browser. <em>(Psst... Save a bookmark for quick access!)</em>
   </p>
 
@@ -18,7 +18,7 @@
   <h4>Mobile Devices Installation</h4>
 
   <p>
-    You can also install and run Lexin Light as mobile application. See our step-by-step instructions on how to install this application to your iPhone/iPad. For Android-based devices installation process is similar, just do it using Chrome.
+    You can also install and run Lexin Mobi as mobile application. See our step-by-step instructions on how to install this application to your iPhone/iPad. For Android-based devices installation process is similar, just do it using Chrome.
   </p>
 
   <table class="about-screenshots">
@@ -76,7 +76,7 @@
   <h4>Native-like Experience</h4>
 
   <p>
-    It's much easier to work with Lexin Light after installation. It's more accessible via a shortcut icon on the phone screen, it looks and feels like a native mobile application, and it's easy to switch between it and other applications.
+    It's much easier to work with Lexin Mobi after installation. It's more accessible via a shortcut icon on the phone screen, it looks and feels like a native mobile application, and it's easy to switch between it and other applications.
   </p>
 
   <table class="about-screenshots">
@@ -86,7 +86,7 @@
           <img
             loading="lazy"
             src="https://user-images.githubusercontent.com/113878/142288546-ed690ba9-cdda-44a6-bd9e-283b0ccc7f9b.png"
-            alt="Example of phone screen of Lexin Light running as installed application with language list opened"
+            alt="Example of phone screen of Lexin Mobi running as installed application with language list opened"
           />
         </a>
       </td>
@@ -96,7 +96,7 @@
           <img
             loading="lazy"
             src="https://user-images.githubusercontent.com/113878/142288551-a198a9f8-f3be-4fba-a538-44a2823754b4.png"
-            alt="Example of phone screen of Lexin Light running as installed application with Russian language chosen"
+            alt="Example of phone screen of Lexin Mobi running as installed application with Russian language chosen"
           />
         </a>
       </td>
@@ -106,7 +106,7 @@
           <img
             loading="lazy"
             src="https://user-images.githubusercontent.com/113878/142288553-fc7d4bd7-4449-4f26-ad6e-50b9cae511da.png"
-            alt="Example of phone screen of Lexin Light running in Safari browser with Finnish language chosen"
+            alt="Example of phone screen of Lexin Mobi running in Safari browser with Finnish language chosen"
           />
         </a>
       </td>
@@ -126,7 +126,7 @@
           <img
             loading="lazy"
             src="https://user-images.githubusercontent.com/113878/142288556-b5f917b6-7e90-4fa1-94ef-7fdc35ae66ed.png"
-            alt="Example of tablet split screen (between book reader and Lexin Light) with Greek language chosen"
+            alt="Example of tablet split screen (between book reader and Lexin Mobi) with Greek language chosen"
           />
         </a>
       </td>
@@ -136,7 +136,7 @@
           <img
             loading="lazy"
             src="https://user-images.githubusercontent.com/113878/142288560-731cc23b-0a76-484f-adc8-3ac970672ec1.png"
-            alt="Example of tablet split screen (between book reader and Lexin Light) with Russian language chosen"
+            alt="Example of tablet split screen (between book reader and Lexin Mobi) with Russian language chosen"
           />
         </a>
       </td>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.9.0",
+      version: "0.9.1",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.8.0",
+      version: "0.9.0",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),

--- a/priv/static/manifest.webmanifest
+++ b/priv/static/manifest.webmanifest
@@ -1,5 +1,5 @@
 {
-  "name": "Lexin Light",
+  "name": "Lexin Mobi",
   "short_name": "Lexin",
   "display": "standalone",
   "background_color": "white",

--- a/test/integration/static_test.exs
+++ b/test/integration/static_test.exs
@@ -11,12 +11,6 @@ defmodule Lexin.StaticTest do
     |> assert_has(
       css(".page_content",
         text:
-          "Lexin – ett samarbete mellan Institutet för språk och folkminnen och Kungliga tekniska högskolan."
-      )
-    )
-    |> assert_has(
-      css(".page_content",
-        text:
           "We have built this little application to improve user experience for end users. The functionality this app provides is very basic: pick a language and search for the word. That's simple!"
       )
     )
@@ -29,7 +23,7 @@ defmodule Lexin.StaticTest do
     |> assert_has(
       css(".page_content",
         text:
-          "Lexin Light is an open-source project, and you can find its code on GitHub. You are welcome to join the development process, or submit any feature requests or issues you find here."
+          "Lexin Mobi is an open-source project, and you can find its code on GitHub. You are welcome to join the development process, or submit any feature requests or issues you find here."
       )
     )
     |> assert_has(
@@ -46,13 +40,13 @@ defmodule Lexin.StaticTest do
     |> assert_has(
       css(".page_content",
         text:
-          "You can use Lexin Light by opening it as a website in your favorite browser. (Psst... Save a bookmark for quick access!)"
+          "You can use Lexin Mobi by opening it as a website in your favorite browser. (Psst... Save a bookmark for quick access!)"
       )
     )
     |> assert_has(
       css(".page_content",
         text:
-          "You can also install and run Lexin Light as mobile application. See our step-by-step instructions on how to install this application to your iPhone/iPad. For Android-based devices installation process is similar, just do it using Chrome."
+          "You can also install and run Lexin Mobi as mobile application. See our step-by-step instructions on how to install this application to your iPhone/iPad. For Android-based devices installation process is similar, just do it using Chrome."
       )
     )
   end


### PR DESCRIPTION
We bought a new short domain for this project – https://lexin.mobi

In order to align UI elements, we decided to slightly rename the project from "Lexin Light" to "Lexin Mobi". Mobile idea was the main UI/UX improvement idea.