### PR TITLE
Add check for unused dependencies to CI flow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Check code formatting
         run: mix format --check-formatted
 
+      - name: Check for unused dependencies
+        run: mix deps.unlock --check-unused
+
       - name: Analyze code
         run: mix credo suggest --ignore todo
 


### PR DESCRIPTION
`mix deps.unlock --check-unused` command checks if any of the dependencies from `mix.lock` file are not in use anymore.

This might happen when we delete a dep from `mix.exs` file, but forget to clean up `mix.lock` one.

Source of the hint: https://twitter.com/rudmanusachi/status/1597341690653999106