### PR TITLE
Fix typos

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -23,7 +23,7 @@ $ asdf elixir reshim
 
 ### Run Livebook
 
-Now we can simply run the server (preferrably from the root directory of this repository or from
+Now we can simply run the server (preferably from the root directory of this repository or from
 the `experiments/`):
 
 ```console

--- a/lib/lexin/dictionary/data.ex
+++ b/lib/lexin/dictionary/data.ex
@@ -111,7 +111,7 @@ defmodule Lexin.Dictionary.Data do
   # for `dammsugare` query value of the most relevant definition is `damm|sugare`
   #
   # TODO: We should try to avoid this data transformation on the Elixir side, and probably try to
-  # achieve the same in SQL query; worth to cheeck this opportunity.
+  # achieve the same in SQL query; worth to cheek this opportunity.
   defp reorder(definitions, query) do
     top_relevant =
       Enum.filter(definitions, fn %{value: word} ->

--- a/lib/lexin/dictionary/parser.ex
+++ b/lib/lexin/dictionary/parser.ex
@@ -17,7 +17,7 @@ defmodule Lexin.Dictionary.Parser do
   end
 
   # TODO: Check and fix parsing according to LexinSchema.xsd. For example, we need to follow
-  # number of occurences for different sub-pieces of definition (only one synonym, for example).
+  # number of occurrences for different sub-pieces of definition (only one synonym, for example).
   defp parse_lang(html) do
     %Lexin.Definition.Lang{
       meaning: child_text(html, "meaning"),


### PR DESCRIPTION
Found via `codespell -S deps,priv -L som, ndoes,pris,exempel`