### PR TITLE
Little UI improvements

### DIFF
--- a/lib/lexin_web/live/components/search_form_component.html.heex
+++ b/lib/lexin_web/live/components/search_form_component.html.heex
@@ -1,10 +1,10 @@
 <form id={@id} phx-target={@myself} phx-submit="submit" phx-hook="saveLanguage">
   <div id="form_header">
     <div class="logo">
-      <a href="/" class="logo-wrapper">
+      <.link patch={~p"/"} class="logo-wrapper">
         <img class="logo-img" src={~p"/images/icon.svg"} />
         <span class="logo-text">Mobi</span>
-      </a>
+      </.link>
     </div>
 
     <select id="form-lang" name="lang" phx-target={@myself} phx-change="switch-language">

--- a/lib/lexin_web/live/dictionary_live/index.ex
+++ b/lib/lexin_web/live/dictionary_live/index.ex
@@ -30,12 +30,13 @@ defmodule LexinWeb.DictionaryLive.Index do
 
   By default (if user opens a page without query parameter) we set everything to clean state.
   """
-  def handle_params(params, uri, socket)
-
   def handle_params(%{"query" => query, "lang" => lang}, _uri, socket) do
+    query = String.trim(query)
+
     socket =
       assign(socket, %{
-        query: String.trim(query),
+        query: query,
+        page_title: page_title(query),
         in_focus: socket.assigns[:in_focus] || true,
         suggestions: [],
         lang: lang
@@ -45,9 +46,12 @@ defmodule LexinWeb.DictionaryLive.Index do
   end
 
   def handle_params(_params, _uri, socket) do
+    query = ""
+
     socket =
       assign(socket, %{
-        query: "",
+        query: query,
+        page_title: page_title(query),
         in_focus: socket.assigns[:in_focus] || true,
         suggestions: [],
         definitions: []
@@ -78,6 +82,9 @@ defmodule LexinWeb.DictionaryLive.Index do
       assign(socket, :definitions, [])
     end
   end
+
+  defp page_title(""), do: "Lexin Mobi"
+  defp page_title(q), do: "#{q} · Lexin Mobi"
 
   defp error_msg(:not_found),
     do: dgettext("errors", "Not found")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.9.5",
+      version: "0.9.6",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/search_test.exs
+++ b/test/integration/search_test.exs
@@ -109,4 +109,27 @@ defmodule Lexin.SearchTest do
     |> assert_has(css("#definition-918", text: "avgas|system avgas|systemet — exhaust system"))
     |> assert_has(css("#definition-918", text: "avgas|rör — exhaust pipe"))
   end
+
+  feature "shows query word in the page title", %{session: session} do
+    session
+    |> visit("/")
+    |> then(fn session ->
+      assert(
+        page_title(session) === "Lexin Mobi",
+        "if query is empty, the title is default"
+      )
+
+      session
+    end)
+    |> fill_in(@lang_select, with: "ryska")
+    |> fill_in(@query_input, with: "a conto")
+    |> click(@submit_button)
+    |> assert_has(css("#definition-5", text: "i förskott"))
+    |> then(fn session ->
+      assert(
+        page_title(session) === "a conto · Lexin Mobi",
+        "when user submits a query, we show it in the page's title"
+      )
+    end)
+  end
 end


### PR DESCRIPTION
We had a couple of UI tiny things that we wanted to adjust.

## Logo Behavior

The top left logo on the search form page (the home page) behaved a bit weird before this changes: when a user clicks on the link, the browser does a full refresh of the page, including reconnection to the websocket and re-mounting general live view (the search form); this led to the noticeable “jumpy” change in the language selector (because we pre-fill it with the language stored in user's `localStorage`).

We have used a standard .link live view component and instructed it to do the patch action (see docs), so we don't re-mount live view and there is no “jumpy” behavior of the language selector anymore.

## Query in the Page's Title

We wanted to leverage the ability to distinguish Lexin results if a user opened multiple tabs; to achieve this, we used LiveView feature that allows us to update the page's `<title>` tag content on the fly.