### PR TITLE
Set previously saved language quickly

### DIFF
--- a/lib/lexin_web/live/components/search_form_component.html.heex
+++ b/lib/lexin_web/live/components/search_form_component.html.heex
@@ -11,6 +11,13 @@
         <option value="select_language"><%= gettext("Select language") %></option>
         <%= Phoenix.HTML.Form.options_for_select(localized_languages(), @lang) %>
       </select>
+
+      <script>
+        <% # set previosly saved language as soon as possible to hide selector UI "jumping" %>
+        if (localStorage) {
+          document.getElementById('form-lang').value = localStorage.getItem('language')
+        }
+      </script>
     </div>
 
     <div class="relative w-full">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.11.1",
+      version: "0.11.2",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
To avoid (a bit) annoying language dropdown UI jumps when the front page is loading (before we set it through LiveView), we decided to write a tiny JS hack. It loads previously saved language from local storage and sets it as soon as possible in the language selector.

For new users, no language will be set, and they still see "Valj sprak" option in this dropdown.
