### PR TITLE
Improve Suggestions Quality

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.11.2",
+      version: "0.12.0",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Previously, we didn't pay too much attention to the suggestions list that we get from SQLite. For the request like "bil" we would show users quite irrelevant suggestions at the top of the list (especially because we limit this list length). As for "bil", we were showing these suggestions:

- bildad
- bildade
- bildat
- bildning
- bildningen

With these changes, we now get all the similar words from SQLite (that start as our query) and then sort them by similarity (Elixir has a great helper for that job – `String.bag_distance/2`). So, now for the same "bil" query, users will see these suggestions:

- bil
- bila
- bild
- bill
- bilen
- bilar
- bilan
- bilor

P.S. We have also increased the default number from 5 to 8 items in the list to show to a user.

### Screenshots

| Before | After |
|--------|-------|
| <img width="612" alt="image" src="https://github.com/cr0t/lexin/assets/113878/09568d30-f245-41d7-8cfc-438c5b5042ca"> | <img width="612" alt="image" src="https://github.com/cr0t/lexin/assets/113878/3c8dcd4a-9e06-4856-81fb-18b108a57ae3"> |
