### PR TITLE
Show comments field

### DIFF
--- a/lib/lexin_web/components/cards/definition.html.heex
+++ b/lib/lexin_web/components/cards/definition.html.heex
@@ -36,8 +36,9 @@
       <%= gettext("Usage: %{usage}", usage: @dfn.base.usage) %>
     </div>
 
-    <div :if={@dfn.target.translation} class="mt-3 font-bold">
-      <%= @dfn.target.translation %>
+    <div :if={@dfn.target.translation} class="mt-3">
+      <span class="font-bold"><%= @dfn.target.translation %></span>
+      <span :if={@dfn.target.comment} class="dimmed">(<%= @dfn.target.comment %>)</span>
     </div>
 
     <div :if={length(@dfn.target.synonyms) > 0} class="dimmed">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.12.0",
+      version: "0.12.1",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/search_test.exs
+++ b/test/integration/search_test.exs
@@ -38,11 +38,11 @@ defmodule Lexin.SearchTest do
     session
     |> visit("/")
     |> fill_in(@lang_select, with: "ryska")
-    |> fill_in(@query_input, with: "a conto")
+    |> fill_in(@query_input, with: "a")
     |> click(@submit_button)
-    |> assert_has(css("#definition-5", text: "i förskott"))
-    |> assert_has(css("#definition-5", text: "А-конто"))
-    |> assert_has(css("#definition-5", text: "(на мой счёт)"))
+    |> assert_has(css("#definition-4", text: "sjätte tonen i C-durskalan"))
+    |> assert_has(css("#definition-4", text: "ля"))
+    |> assert_has(css("#definition-4", text: "(\"музыкальный термин (шестая нота гаммы)"))
   end
 
   feature "switches definition to another available language", %{session: session} do


### PR DESCRIPTION
Seems we overlooked rendering this field previously, though we even
parsed it and have it in the Lang data type.

So, let's show it because comments often mention important context for the word's usage.

### Screenshots

_The difference is subtle, but it's there. Compare._

| Before | After |
|--------|-------|
| <img width="612" alt="image" src="https://github.com/cr0t/lexin/assets/113878/5e1e37fb-c69e-4eee-97bd-4d359331aafc"> | <img width="612" alt="image" src="https://github.com/cr0t/lexin/assets/113878/a2938cb0-1e5d-48ef-8bee-d35d167d752a"> |