### PR TITLE
Add Plausible Analytics snippet to the site

### DIFF
--- a/lib/lexin_web/components/layouts/root.html.heex
+++ b/lib/lexin_web/components/layouts/root.html.heex
@@ -27,6 +27,9 @@
     <% # NOTE: sync dark theme-color with the dark:bg-... of body tag if you change it %>
 
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+
+    <script defer data-domain="lexin.mobi" src="https://plausible.summercode.com/js/script.js">
+    </script>
   </head>
 
   <body>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.12.3",
+      version: "0.12.4",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Why?

To learn how many (or if any at all) users use this website/application.

### Some More Context

The actual analytics instance is running on the same server, but under the different domain (plausible.summercode.com).

More information about Plausible Analytics can be found on their website. But one of the most important things is that we do not need to show a Cookie consent prompts or any GDPR-related banners because this analytics tool is built with privacy in mind, check more information here: https://plausible.io/privacy-focused-web-analytics.