### PR TITLE
Set translation language automatically

### DIFF
--- a/assets/js/lexin.js
+++ b/assets/js/lexin.js
@@ -36,16 +36,9 @@ let hooks = {
   }
 }
 
-let params = () => {
-  let params = {
-    _csrf_token: document.querySelector("meta[name='csrf-token']").getAttribute('content')
-  }
-
-  if (localStorage) {
-    params['lang'] = localStorage.getItem(LANG_KEY)
-  }
-
-  return params
+let params = {
+ _csrf_token: document.querySelector("meta[name='csrf-token']").getAttribute('content'),
+ lang: window.preferredLanguage() // see layouts.ex and _lang_js_utils.html.heex for details
 }
 
 let socketParams = {

--- a/lib/lexin_web/components/layouts.ex
+++ b/lib/lexin_web/components/layouts.ex
@@ -6,4 +6,40 @@ defmodule LexinWeb.Layouts do
   embed_templates "layouts/*"
 
   def app_version(), do: Application.get_env(:lexin, :app_version)
+
+  @doc """
+  Returns a map of IETF Language Tag standard names to the internal languages our app supports.
+
+  We used https://en.wikipedia.org/wiki/IETF_language_tag#List_of_common_primary_language_subtags
+  as the information for making this mapping of default language for translations.
+
+  This map is being rendered inline in JavaScript code.
+
+  [!NOTE]
+  Somali and Tigrinya languages default to English
+  """
+  def default_languages_mapping() do
+    %{
+      "sq" => "albanian",
+      "am" => "amharic",
+      "ar" => "arabic",
+      "az" => "azerbaijani",
+      "bs" => "bosnian",
+      "en" => "english",
+      "fi" => "finnish",
+      "el" => "greek",
+      "hr" => "croatian",
+      "ckb" => "northern_kurdish",
+      "ps" => "pashto",
+      "fa" => "persian",
+      "ru" => "russian",
+      "sr" => "serbian_latin",
+      "es" => "spanish",
+      "sv" => "swedish",
+      "tr" => "turkish"
+    }
+    |> Jason.encode!()
+    |> Phoenix.HTML.raw()
+  end
+
 end

--- a/lib/lexin_web/components/layouts.ex
+++ b/lib/lexin_web/components/layouts.ex
@@ -41,5 +41,4 @@ defmodule LexinWeb.Layouts do
     |> Jason.encode!()
     |> Phoenix.HTML.raw()
   end
-
 end

--- a/lib/lexin_web/components/layouts/_lang_js_utils.html.heex
+++ b/lib/lexin_web/components/layouts/_lang_js_utils.html.heex
@@ -1,0 +1,37 @@
+<script>
+  const DEFAULT_LANG_MAPPING = <%= default_languages_mapping() %>;
+  const DEFAULT_LANG = 'english';
+
+  function findQueryParameter(parameterName) {
+    let result = null, tmp = [];
+
+    location.search.substr(1).split("&").forEach(function (item) {
+      tmp = item.split("=");
+
+      if (tmp[0] === parameterName) {
+        result = decodeURIComponent(tmp[1]);
+      }
+    })
+
+    return result;
+  }
+
+  window.preferredLanguage = function() {
+    const browserLanguage = navigator.language.split('-')[0];
+    const savedLanguage = localStorage.getItem('language');
+    const queryLanguage = findQueryParameter('lang');
+
+    if (queryLanguage !== null) {
+      return queryLanguage;
+    }
+    else if (savedLanguage !== null) {
+      return savedLanguage;
+    }
+    else if (typeof browserLanguage === 'string') {
+      return DEFAULT_LANG_MAPPING[browserLanguage];
+    }
+    else {
+      return DEFAULT_LANG;
+    }
+  }
+</script>

--- a/lib/lexin_web/components/layouts/root.html.heex
+++ b/lib/lexin_web/components/layouts/root.html.heex
@@ -28,6 +28,8 @@
 
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
 
+    <._lang_js_utils />
+
     <script defer data-domain="lexin.mobi" src="https://plausible.summercode.com/js/script.js">
     </script>
   </head>

--- a/lib/lexin_web/live/components/search_form_component.html.heex
+++ b/lib/lexin_web/live/components/search_form_component.html.heex
@@ -5,18 +5,16 @@
         class="selector--lang"
         id="form-lang"
         name="lang"
+        title={gettext("Select language")}
         phx-target={@myself}
         phx-change="switch-language"
       >
-        <option value="select_language"><%= gettext("Select language") %></option>
         <%= Phoenix.HTML.Form.options_for_select(localized_languages(), @lang) %>
       </select>
 
       <script>
         <% # set previosly saved language as soon as possible to hide selector UI "jumping" %>
-        if (localStorage) {
-          document.getElementById('form-lang').value = localStorage.getItem('language')
-        }
+        document.getElementById('form-lang').value = window.preferredLanguage();
       </script>
     </div>
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.12.4",
+      version: "0.13.0",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -20,7 +20,7 @@ msgstr ""
 msgid "compare"
 msgstr ""
 
-#: lib/lexin_web/components/serp_components.ex:128
+#: lib/lexin_web/components/serp_components.ex:126
 #, elixir-autogen, elixir-format
 msgid "listen"
 msgstr ""
@@ -35,152 +35,152 @@ msgstr ""
 msgid "Usage: %{usage}"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:50
+#: lib/lexin_web/components/cards/definition.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Antonyms: %{antonyms}"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:55
+#: lib/lexin_web/components/cards/definition.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "Examples"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:68
+#: lib/lexin_web/components/cards/definition.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Idioms"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:81
+#: lib/lexin_web/components/cards/definition.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Compounds"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:94
+#: lib/lexin_web/components/cards/definition.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Derivations"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:107
+#: lib/lexin_web/components/cards/definition.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Extra"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:51
+#: lib/lexin_web/live/components/search_form_component.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:11
+#: lib/lexin_web/live/components/search_form_component.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Select language"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:55
+#: lib/lexin_web/live/components/search_form_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "albanian"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:56
+#: lib/lexin_web/live/components/search_form_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "amharic"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:57
+#: lib/lexin_web/live/components/search_form_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "arabic"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:58
+#: lib/lexin_web/live/components/search_form_component.ex:64
 #, elixir-autogen, elixir-format
 msgid "azerbaijani"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:59
+#: lib/lexin_web/live/components/search_form_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "bosnian"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:60
+#: lib/lexin_web/live/components/search_form_component.ex:66
 #, elixir-autogen, elixir-format
 msgid "english"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:61
+#: lib/lexin_web/live/components/search_form_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "finnish"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:62
+#: lib/lexin_web/live/components/search_form_component.ex:68
 #, elixir-autogen, elixir-format
 msgid "greek"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:63
+#: lib/lexin_web/live/components/search_form_component.ex:69
 #, elixir-autogen, elixir-format
 msgid "croatian"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:64
+#: lib/lexin_web/live/components/search_form_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "northern_kurdish"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:65
+#: lib/lexin_web/live/components/search_form_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "pashto"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:66
+#: lib/lexin_web/live/components/search_form_component.ex:72
 #, elixir-autogen, elixir-format
 msgid "persian"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:67
+#: lib/lexin_web/live/components/search_form_component.ex:73
 #, elixir-autogen, elixir-format
 msgid "russian"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:68
+#: lib/lexin_web/live/components/search_form_component.ex:74
 #, elixir-autogen, elixir-format
 msgid "serbian_latin"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:69
+#: lib/lexin_web/live/components/search_form_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "serbian_cyrillic"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:70
+#: lib/lexin_web/live/components/search_form_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "somali"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:71
+#: lib/lexin_web/live/components/search_form_component.ex:77
 #, elixir-autogen, elixir-format
 msgid "spanish"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:72
+#: lib/lexin_web/live/components/search_form_component.ex:78
 #, elixir-autogen, elixir-format
 msgid "swedish"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:73
+#: lib/lexin_web/live/components/search_form_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "southern_kurdish"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:74
+#: lib/lexin_web/live/components/search_form_component.ex:80
 #, elixir-autogen, elixir-format
 msgid "tigrinya"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:75
+#: lib/lexin_web/live/components/search_form_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "turkish"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:32
+#: lib/lexin_web/live/components/search_form_component.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Start typing a word..."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr ""
 msgid "compare"
 msgstr ""
 
-#: lib/lexin_web/components/serp_components.ex:128
+#: lib/lexin_web/components/serp_components.ex:126
 #, elixir-autogen, elixir-format
 msgid "listen"
 msgstr ""
@@ -36,152 +36,152 @@ msgstr ""
 msgid "Usage: %{usage}"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:50
+#: lib/lexin_web/components/cards/definition.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Antonyms: %{antonyms}"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:55
+#: lib/lexin_web/components/cards/definition.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "Examples"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:68
+#: lib/lexin_web/components/cards/definition.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Idioms"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:81
+#: lib/lexin_web/components/cards/definition.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Compounds"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:94
+#: lib/lexin_web/components/cards/definition.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Derivations"
 msgstr ""
 
-#: lib/lexin_web/components/cards/definition.html.heex:107
+#: lib/lexin_web/components/cards/definition.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Extra"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:51
+#: lib/lexin_web/live/components/search_form_component.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:11
+#: lib/lexin_web/live/components/search_form_component.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Select language"
 msgstr ""
 
-#: lib/lexin_web/live/components/search_form_component.ex:55
+#: lib/lexin_web/live/components/search_form_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "albanian"
 msgstr "Albanian"
 
-#: lib/lexin_web/live/components/search_form_component.ex:56
+#: lib/lexin_web/live/components/search_form_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "amharic"
 msgstr "Amharic"
 
-#: lib/lexin_web/live/components/search_form_component.ex:57
+#: lib/lexin_web/live/components/search_form_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "arabic"
 msgstr "Arabic"
 
-#: lib/lexin_web/live/components/search_form_component.ex:58
+#: lib/lexin_web/live/components/search_form_component.ex:64
 #, elixir-autogen, elixir-format
 msgid "azerbaijani"
 msgstr "Azerbaijani"
 
-#: lib/lexin_web/live/components/search_form_component.ex:59
+#: lib/lexin_web/live/components/search_form_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "bosnian"
 msgstr "Bosnian"
 
-#: lib/lexin_web/live/components/search_form_component.ex:60
+#: lib/lexin_web/live/components/search_form_component.ex:66
 #, elixir-autogen, elixir-format
 msgid "english"
 msgstr "English"
 
-#: lib/lexin_web/live/components/search_form_component.ex:61
+#: lib/lexin_web/live/components/search_form_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "finnish"
 msgstr "Finnish"
 
-#: lib/lexin_web/live/components/search_form_component.ex:62
+#: lib/lexin_web/live/components/search_form_component.ex:68
 #, elixir-autogen, elixir-format
 msgid "greek"
 msgstr "Greek"
 
-#: lib/lexin_web/live/components/search_form_component.ex:63
+#: lib/lexin_web/live/components/search_form_component.ex:69
 #, elixir-autogen, elixir-format
 msgid "croatian"
 msgstr "Croatian"
 
-#: lib/lexin_web/live/components/search_form_component.ex:64
+#: lib/lexin_web/live/components/search_form_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "northern_kurdish"
 msgstr "Northern Kurdish"
 
-#: lib/lexin_web/live/components/search_form_component.ex:65
+#: lib/lexin_web/live/components/search_form_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "pashto"
 msgstr "Pashto"
 
-#: lib/lexin_web/live/components/search_form_component.ex:66
+#: lib/lexin_web/live/components/search_form_component.ex:72
 #, elixir-autogen, elixir-format
 msgid "persian"
 msgstr "Persian"
 
-#: lib/lexin_web/live/components/search_form_component.ex:67
+#: lib/lexin_web/live/components/search_form_component.ex:73
 #, elixir-autogen, elixir-format
 msgid "russian"
 msgstr "Russian"
 
-#: lib/lexin_web/live/components/search_form_component.ex:68
+#: lib/lexin_web/live/components/search_form_component.ex:74
 #, elixir-autogen, elixir-format
 msgid "serbian_latin"
 msgstr "Serbian (Latin)"
 
-#: lib/lexin_web/live/components/search_form_component.ex:69
+#: lib/lexin_web/live/components/search_form_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "serbian_cyrillic"
 msgstr "Serbian (Cyrillic)"
 
-#: lib/lexin_web/live/components/search_form_component.ex:70
+#: lib/lexin_web/live/components/search_form_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "somali"
 msgstr "Somali"
 
-#: lib/lexin_web/live/components/search_form_component.ex:71
+#: lib/lexin_web/live/components/search_form_component.ex:77
 #, elixir-autogen, elixir-format
 msgid "spanish"
 msgstr "Spanish"
 
-#: lib/lexin_web/live/components/search_form_component.ex:72
+#: lib/lexin_web/live/components/search_form_component.ex:78
 #, elixir-autogen, elixir-format
 msgid "swedish"
 msgstr "Swedish"
 
-#: lib/lexin_web/live/components/search_form_component.ex:73
+#: lib/lexin_web/live/components/search_form_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "southern_kurdish"
 msgstr "Southern Kurdish"
 
-#: lib/lexin_web/live/components/search_form_component.ex:74
+#: lib/lexin_web/live/components/search_form_component.ex:80
 #, elixir-autogen, elixir-format
 msgid "tigrinya"
 msgstr "Tigrinya"
 
-#: lib/lexin_web/live/components/search_form_component.ex:75
+#: lib/lexin_web/live/components/search_form_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "turkish"
 msgstr "Turkish"
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:32
+#: lib/lexin_web/live/components/search_form_component.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Start typing a word..."
 msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr "смотреть"
 msgid "compare"
 msgstr "сравнить"
 
-#: lib/lexin_web/components/serp_components.ex:128
+#: lib/lexin_web/components/serp_components.ex:126
 #, elixir-autogen, elixir-format
 msgid "listen"
 msgstr "слушать"
@@ -36,152 +36,152 @@ msgstr "Альтернатива: %{alt}"
 msgid "Usage: %{usage}"
 msgstr "Использование: %{usage}"
 
-#: lib/lexin_web/components/cards/definition.html.heex:50
+#: lib/lexin_web/components/cards/definition.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Antonyms: %{antonyms}"
 msgstr "Антонимы: %{antonyms}"
 
-#: lib/lexin_web/components/cards/definition.html.heex:55
+#: lib/lexin_web/components/cards/definition.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "Examples"
 msgstr "Примеры"
 
-#: lib/lexin_web/components/cards/definition.html.heex:68
+#: lib/lexin_web/components/cards/definition.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Idioms"
 msgstr "Идиомы"
 
-#: lib/lexin_web/components/cards/definition.html.heex:81
+#: lib/lexin_web/components/cards/definition.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Compounds"
 msgstr "Составные слова"
 
-#: lib/lexin_web/components/cards/definition.html.heex:94
+#: lib/lexin_web/components/cards/definition.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Derivations"
 msgstr "Словообразования"
 
-#: lib/lexin_web/components/cards/definition.html.heex:107
+#: lib/lexin_web/components/cards/definition.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Extra"
 msgstr "Дополнительно"
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:51
+#: lib/lexin_web/live/components/search_form_component.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Искать"
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:11
+#: lib/lexin_web/live/components/search_form_component.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Select language"
 msgstr "Выберите язык"
 
-#: lib/lexin_web/live/components/search_form_component.ex:55
+#: lib/lexin_web/live/components/search_form_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "albanian"
 msgstr "Албанский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:56
+#: lib/lexin_web/live/components/search_form_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "amharic"
 msgstr "Амхарский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:57
+#: lib/lexin_web/live/components/search_form_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "arabic"
 msgstr "Арабский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:58
+#: lib/lexin_web/live/components/search_form_component.ex:64
 #, elixir-autogen, elixir-format
 msgid "azerbaijani"
 msgstr "Азербайджанский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:59
+#: lib/lexin_web/live/components/search_form_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "bosnian"
 msgstr "Боснийский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:60
+#: lib/lexin_web/live/components/search_form_component.ex:66
 #, elixir-autogen, elixir-format
 msgid "english"
 msgstr "Английский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:61
+#: lib/lexin_web/live/components/search_form_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "finnish"
 msgstr "Финский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:62
+#: lib/lexin_web/live/components/search_form_component.ex:68
 #, elixir-autogen, elixir-format
 msgid "greek"
 msgstr "Греческий"
 
-#: lib/lexin_web/live/components/search_form_component.ex:63
+#: lib/lexin_web/live/components/search_form_component.ex:69
 #, elixir-autogen, elixir-format
 msgid "croatian"
 msgstr "Хорватский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:64
+#: lib/lexin_web/live/components/search_form_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "northern_kurdish"
 msgstr "Севернокурдский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:65
+#: lib/lexin_web/live/components/search_form_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "pashto"
 msgstr "Пушту"
 
-#: lib/lexin_web/live/components/search_form_component.ex:66
+#: lib/lexin_web/live/components/search_form_component.ex:72
 #, elixir-autogen, elixir-format
 msgid "persian"
 msgstr "Персидский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:67
+#: lib/lexin_web/live/components/search_form_component.ex:73
 #, elixir-autogen, elixir-format
 msgid "russian"
 msgstr "Русский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:68
+#: lib/lexin_web/live/components/search_form_component.ex:74
 #, elixir-autogen, elixir-format
 msgid "serbian_latin"
 msgstr "Сербский (латиница)"
 
-#: lib/lexin_web/live/components/search_form_component.ex:69
+#: lib/lexin_web/live/components/search_form_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "serbian_cyrillic"
 msgstr "Сербский (кириллица)"
 
-#: lib/lexin_web/live/components/search_form_component.ex:70
+#: lib/lexin_web/live/components/search_form_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "somali"
 msgstr "Сомалийский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:71
+#: lib/lexin_web/live/components/search_form_component.ex:77
 #, elixir-autogen, elixir-format
 msgid "spanish"
 msgstr "Испанский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:72
+#: lib/lexin_web/live/components/search_form_component.ex:78
 #, elixir-autogen, elixir-format
 msgid "swedish"
 msgstr "Шведский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:73
+#: lib/lexin_web/live/components/search_form_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "southern_kurdish"
 msgstr "Южнокурдский"
 
-#: lib/lexin_web/live/components/search_form_component.ex:74
+#: lib/lexin_web/live/components/search_form_component.ex:80
 #, elixir-autogen, elixir-format
 msgid "tigrinya"
 msgstr "Тигринья"
 
-#: lib/lexin_web/live/components/search_form_component.ex:75
+#: lib/lexin_web/live/components/search_form_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "turkish"
 msgstr "Турецкий"
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:32
+#: lib/lexin_web/live/components/search_form_component.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Start typing a word..."
 msgstr ""

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr "visa film"
 msgid "compare"
 msgstr "jämför"
 
-#: lib/lexin_web/components/serp_components.ex:128
+#: lib/lexin_web/components/serp_components.ex:126
 #, elixir-autogen, elixir-format
 msgid "listen"
 msgstr "lyssna"
@@ -36,152 +36,152 @@ msgstr "Variantform: %{alt}"
 msgid "Usage: %{usage}"
 msgstr "Användning: %{usage}"
 
-#: lib/lexin_web/components/cards/definition.html.heex:50
+#: lib/lexin_web/components/cards/definition.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Antonyms: %{antonyms}"
 msgstr "Motsatser: %{antonyms}"
 
-#: lib/lexin_web/components/cards/definition.html.heex:55
+#: lib/lexin_web/components/cards/definition.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "Examples"
 msgstr "Exempel"
 
-#: lib/lexin_web/components/cards/definition.html.heex:68
+#: lib/lexin_web/components/cards/definition.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Idioms"
 msgstr "Uttryck"
 
-#: lib/lexin_web/components/cards/definition.html.heex:81
+#: lib/lexin_web/components/cards/definition.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Compounds"
 msgstr "Sammansättningar"
 
-#: lib/lexin_web/components/cards/definition.html.heex:94
+#: lib/lexin_web/components/cards/definition.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Derivations"
 msgstr "Avledningar"
 
-#: lib/lexin_web/components/cards/definition.html.heex:107
+#: lib/lexin_web/components/cards/definition.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Extra"
 msgstr "Extra"
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:51
+#: lib/lexin_web/live/components/search_form_component.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Sök"
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:11
+#: lib/lexin_web/live/components/search_form_component.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Select language"
 msgstr "Välj språk"
 
-#: lib/lexin_web/live/components/search_form_component.ex:55
+#: lib/lexin_web/live/components/search_form_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "albanian"
 msgstr "Albanska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:56
+#: lib/lexin_web/live/components/search_form_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "amharic"
 msgstr "Amhariska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:57
+#: lib/lexin_web/live/components/search_form_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "arabic"
 msgstr "Arabiska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:58
+#: lib/lexin_web/live/components/search_form_component.ex:64
 #, elixir-autogen, elixir-format
 msgid "azerbaijani"
 msgstr "Azerbajdzjanska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:59
+#: lib/lexin_web/live/components/search_form_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "bosnian"
 msgstr "Bosniska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:60
+#: lib/lexin_web/live/components/search_form_component.ex:66
 #, elixir-autogen, elixir-format
 msgid "english"
 msgstr "Engelska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:61
+#: lib/lexin_web/live/components/search_form_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "finnish"
 msgstr "Finska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:62
+#: lib/lexin_web/live/components/search_form_component.ex:68
 #, elixir-autogen, elixir-format
 msgid "greek"
 msgstr "Grekiska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:63
+#: lib/lexin_web/live/components/search_form_component.ex:69
 #, elixir-autogen, elixir-format
 msgid "croatian"
 msgstr "Kroatiska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:64
+#: lib/lexin_web/live/components/search_form_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "northern_kurdish"
 msgstr "Nordkurdiska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:65
+#: lib/lexin_web/live/components/search_form_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "pashto"
 msgstr "Pashto"
 
-#: lib/lexin_web/live/components/search_form_component.ex:66
+#: lib/lexin_web/live/components/search_form_component.ex:72
 #, elixir-autogen, elixir-format
 msgid "persian"
 msgstr "Persiska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:67
+#: lib/lexin_web/live/components/search_form_component.ex:73
 #, elixir-autogen, elixir-format
 msgid "russian"
 msgstr "Ryska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:68
+#: lib/lexin_web/live/components/search_form_component.ex:74
 #, elixir-autogen, elixir-format
 msgid "serbian_latin"
 msgstr "Serbiska (latinskt)"
 
-#: lib/lexin_web/live/components/search_form_component.ex:69
+#: lib/lexin_web/live/components/search_form_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "serbian_cyrillic"
 msgstr "Serbiska (kirilliskt)"
 
-#: lib/lexin_web/live/components/search_form_component.ex:70
+#: lib/lexin_web/live/components/search_form_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "somali"
 msgstr "Somaliska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:71
+#: lib/lexin_web/live/components/search_form_component.ex:77
 #, elixir-autogen, elixir-format
 msgid "spanish"
 msgstr "Spanska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:72
+#: lib/lexin_web/live/components/search_form_component.ex:78
 #, elixir-autogen, elixir-format
 msgid "swedish"
 msgstr "Svenska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:73
+#: lib/lexin_web/live/components/search_form_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "southern_kurdish"
 msgstr "Sydkurdiska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:74
+#: lib/lexin_web/live/components/search_form_component.ex:80
 #, elixir-autogen, elixir-format
 msgid "tigrinya"
 msgstr "Tigrinska"
 
-#: lib/lexin_web/live/components/search_form_component.ex:75
+#: lib/lexin_web/live/components/search_form_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "turkish"
 msgstr "Turkiska"
 
-#: lib/lexin_web/live/components/search_form_component.html.heex:32
+#: lib/lexin_web/live/components/search_form_component.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Start typing a word..."
 msgstr "Börja skriva ett ord..."

--- a/test/integration/search_test.exs
+++ b/test/integration/search_test.exs
@@ -8,14 +8,6 @@ defmodule Lexin.SearchTest do
   @lang_select css("#form-lang")
   @submit_button css("#form-submit_button")
 
-  feature "shows an alert if no language is chosen", %{session: session} do
-    session
-    |> visit("/")
-    |> fill_in(@query_input, with: "a conto")
-    |> click(@submit_button)
-    |> assert_has(css("#flash.flash--error", text: "Språk stöds inte"))
-  end
-
   feature "allows to select a translation language", %{session: session} do
     session
     |> visit("/")
@@ -146,5 +138,11 @@ defmodule Lexin.SearchTest do
         "when user submits a query, we show it in the page's title"
       )
     end)
+  end
+
+  feature "shows an alert if wrong language is given in the URL", %{session: session} do
+    session
+    |> visit("/?query=a+conto&lang=albaniska")
+    |> assert_has(css("#flash.flash--error", text: "Språk stöds inte"))
   end
 end

--- a/test/integration/search_test.exs
+++ b/test/integration/search_test.exs
@@ -17,6 +17,38 @@ defmodule Lexin.SearchTest do
     |> refute_has(css("#flash.flash--error"))
   end
 
+  feature "pre-selects the given language in the URL", %{session: session} do
+    session
+    |> visit("/?query=a+conto&lang=russian")
+    |> assert_has(css("#definition-5", text: "на мой счёт"))
+  end
+
+  feature "pre-selects the previously saved language", %{session: session} do
+    session
+    |> visit("/")
+    |> fill_in(@lang_select, with: "ryska")
+    |> visit("/")
+    |> fill_in(@query_input, with: "a conto")
+    |> click(@submit_button)
+    |> assert_has(css("#definition-5", text: "на мой счёт"))
+  end
+
+  feature "pre-selects the language in the URL even is the other was saved", %{session: session} do
+    session
+    |> visit("/")
+    |> fill_in(@lang_select, with: "ryska")
+    |> visit("/?a+conto&lang=english")
+    |> fill_in(@query_input, with: "a conto")
+    |> click(@submit_button)
+    |> assert_has(css("#definition-5", text: "(in advance)"))
+  end
+
+  feature "shows an alert if wrong language is given in the URL", %{session: session} do
+    session
+    |> visit("/?query=a+conto&lang=ruskii")
+    |> assert_has(css("#flash.flash--error", text: "Språk stöds inte"))
+  end
+
   feature "shows an alert if word not found", %{session: session} do
     session
     |> visit("/")
@@ -138,11 +170,5 @@ defmodule Lexin.SearchTest do
         "when user submits a query, we show it in the page's title"
       )
     end)
-  end
-
-  feature "shows an alert if wrong language is given in the URL", %{session: session} do
-    session
-    |> visit("/?query=a+conto&lang=albaniska")
-    |> assert_has(css("#flash.flash--error", text: "Språk stöds inte"))
   end
 end


### PR DESCRIPTION
As we found out, some users do not notice our language selector dropdown, and they stuck when they see 'Sprak stods inte' flash message while searching for a word.

We want to avoid cases like that, and here is what we came up with:

- we check the browser's language, check if any language was already saved during previous sessions, check if a user opened someone's else result page (that sets the `lang` parameter in URL)
- priority to set the preferred language is the next (if any is set):
  1. From URL
  2. Previously saved in local storage
  3. Browser preferred
  4. Default – 'English'
- we also removed 'Select your language' option at all from the dropdown, so we won't show the alert 'Sprak stods inte' – there is always must be at least some language selected.

A note regarding the last point: it is possible to visit a URL with a mistyped language parameter value (the one that we do not support) – in cases like this, users will see 'Sprak stod inte' alert.
