### PR TITLE
Fix non valid character data

### DIFF
--- a/lib/lexin/dictionary/parser.ex
+++ b/lib/lexin/dictionary/parser.ex
@@ -134,7 +134,9 @@ defmodule Lexin.Dictionary.Parser do
   # See more:
   # - https://www.erlang.org/doc/man/unicode.html#characters_to_nfc_list-1
   # - https://www.ic.unicamp.br/~stolfi/EXPORT/www/ISO-8859-1-Encoding.html
-  defp latin1_rename(filename) do
+  defp latin1_rename(nil), do: nil
+
+  defp latin1_rename(filename) when is_binary(filename) do
     filename
     |> :unicode.characters_to_nfc_list()
     |> Enum.map(fn

--- a/lib/lexin/types/phonetic.ex
+++ b/lib/lexin/types/phonetic.ex
@@ -9,6 +9,13 @@ defmodule Lexin.Definition.Phonetic do
 
   @type t :: %__MODULE__{
           transcription: String.t(),
-          audio_url: String.t()
+          audio_url: String.t() | nil
         }
+
+  # NOTE: audio_url can be nil in some rare cases. For example, one of the definitions of Swedish
+  # `stavar` has no `file` attribute in the `phonetic` tag.
+  #
+  # Check:
+  # bash$ sqlite3 english.sqlite
+  # sqlite> SELECT * FROM definitions JOIN vocabulary ON definitions.id = vocabulary.definition_id WHERE vocabulary.word LIKE 'stavar';
 end

--- a/lib/lexin_web/components/serp_components.ex
+++ b/lib/lexin_web/components/serp_components.ex
@@ -116,12 +116,14 @@ defmodule LexinWeb.SerpComponents do
   An anchor tag that plays the given audio file URL when user clicks. We duplicate the URL in the
   `href` attribute, so users can download files or listen in the other way if browser doesn't support
   `playAudio` JS feature.
+
+  In rare cases `file` can be nil: we do not render the 'listen' button then.
   """
-  attr :file, :string, required: true
+  attr :file, :string
 
   def listen_link(assigns) do
     ~H"""
-    <button class="btn--listen" onclick={"playAudio('#{external_audio_url(@file)}')"}>
+    <button :if={@file} class="btn--listen" onclick={"playAudio('#{external_audio_url(@file)}')"}>
       <.icon name="hero-speaker-wave-solid" class="h-3 w-3 mr-1" />
       <%= gettext("listen") %>
     </button>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.13.2",
+      version: "0.13.3",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Fix for `ArgumentError :unicode.characters_to_nfc_list/1`

The error caught by Sentry. There were also a few additional errors that Sentry caught. Original issue URL:

https://lexin-mobi.sentry.io/share/issue/1dbb6b0a69e346e6b627f009a24457c7/

A little digging in the area revealed that in some rare cases (e.g., for Swedish `stavar`), the `<phonetic>...</phonetic>` block of the definition doesn't have the `file` attribute set.

This led to the issue where code was trying to convert the input string, but getting `nil` instead.

To fix that, we updated the `Parser`, `SerpComponents`, and `Phonetic` modules. From now, we show `listen` button optionally: only if the file URL exists and not nil.