### PR TITLE
Fix nils in Open Graph image generation

### DIFF
--- a/lib/lexin_web/controllers/og_image_controller.ex
+++ b/lib/lexin_web/controllers/og_image_controller.ex
@@ -57,12 +57,12 @@ defmodule LexinWeb.OGImageController do
     assigns = [
       base_lang: "Svenska",
       target_lang: String.capitalize(lang),
-      definition: definition.value,
-      transcription: definition.base.phonetic.transcription,
+      definition: get_in(definition.value) || "",
+      transcription: get_in(definition.base.phonetic.transcription) || "",
       inflections: Enum.join(inflections(definition), ", "),
-      meaning: definition.base.meaning,
-      target_translation: definition.target.translation,
-      target_synonyms: Enum.join(definition.target.synonyms, ", ")
+      meaning: get_in(definition.base.meaning) || "",
+      target_translation: get_in(definition.target.translation) || "",
+      target_synonyms: Enum.join(get_in(definition.target.synonyms) || [], ", ")
     ]
 
     {svg, _bindings} = Code.eval_quoted(@template_svg, assigns)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lexin.MixProject do
   def project do
     [
       app: :lexin,
-      version: "0.17.0",
+      version: "0.17.1",
       elixir: "~> 1.16",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
In some cases, we've got `nil` instead of binaries and the template rendering raised an exception. The exception got caught by Sentry: https://lexin-mobi.sentry.io/issues/5794700597/