### PR TITLE
Fix flaky integration tests with (dirty) workaround

### DIFF
--- a/test/integration/search_test.exs
+++ b/test/integration/search_test.exs
@@ -157,6 +157,8 @@ defmodule Lexin.SearchTest do
     |> click(@submit_button)
     |> assert_has(css("#definition-15456", text: "silhuett se siluett"))
     |> then(fn session ->
+      Process.sleep(50)
+
       assert(
         page_title(session) == "silhuett - silhouette",
         "for reference-only words we use translation from the other definition"
@@ -168,6 +170,8 @@ defmodule Lexin.SearchTest do
     session
     |> visit("/")
     |> then(fn session ->
+      Process.sleep(50)
+
       assert(
         page_title(session) == "Lexin.mobi",
         "if query is empty, the title is default"
@@ -180,6 +184,8 @@ defmodule Lexin.SearchTest do
     |> click(@submit_button)
     |> assert_has(css("#definition-5", text: "i förskott"))
     |> then(fn session ->
+      Process.sleep(50)
+
       assert(
         page_title(session) == "a conto - А-конто",
         "when user submits a query, we show it in the page's title"
@@ -195,6 +201,8 @@ defmodule Lexin.SearchTest do
     |> click(@submit_button)
     |> assert_has(css("#definition-15456", text: "silhuett se siluett"))
     |> then(fn session ->
+      Process.sleep(50)
+
       assert(
         page_title(session) == "silhuett",
         "we skip translation from page title if it's not available"


### PR DESCRIPTION
Lately, we have noticed some level of flakiness of the integration tests we run using Wallaby and Chromedriver. They all behave like a race condition in updating HTML titles of the page via LiveView events.

A few links here https://github.com/elixir-wallaby/wallaby/issues/804 led to the assumption that it might be related to the Chromedriver itself, but we cannot dig deeper now.

We decided to go with a dirty workaround using `Process.sleep(50)` (50 milliseconds) that lets to wait the controlling process before it asserts the expected changes to the page title. Multiple local runs (in the same environment that was showing flaky behavior just before the changes) show that it works.