### PR TITLE
Reduce requests per minute from 1000 to 100

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -67,6 +67,11 @@ config :lexin,
 
 config :lexin, :app_version, Mix.Project.config()[:version]
 
+config :hammer,
+  backend: :ets,
+  scale: :timer.minutes(1),
+  limit: 100
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,6 +19,9 @@ config :logger, level: :warning
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 
+# Increase the rate limit for requests in test mode, or Wallaby fails
+config :hammer, limit: 1_000_000
+
 # A few settings for Wallaby
 config :wallaby,
   driver: Wallaby.Chrome,

--- a/lib/lexin/rate_limit.ex
+++ b/lib/lexin/rate_limit.ex
@@ -1,4 +1,4 @@
 defmodule Lexin.RateLimit do
   @moduledoc false
-  use Hammer, backend: :ets
+  use Hammer, backend: Application.compile_env(:hammer, :backend)
 end

--- a/lib/lexin_web/endpoint.ex
+++ b/lib/lexin_web/endpoint.ex
@@ -15,7 +15,8 @@ defmodule LexinWeb.Endpoint do
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
   # No more than requests per minute from one IP address
-  @rate_per_minute 100
+  @rate_scale Application.compile_env(:hammer, :scale)
+  @rate_limit Application.compile_env(:hammer, :limit)
   plug :rate_limit
 
   # Serve at "/" the static files from "priv/static" directory.
@@ -69,10 +70,8 @@ defmodule LexinWeb.Endpoint do
 
   defp rate_limit(conn, _opts) do
     key = "web_requests:#{:inet.ntoa(conn.remote_ip)}"
-    scale = :timer.minutes(1)
-    limit = @rate_per_minute
 
-    case Lexin.RateLimit.hit(key, scale, limit) do
+    case Lexin.RateLimit.hit(key, @rate_scale, @rate_limit) do
       {:allow, _count} ->
         conn
 

--- a/lib/lexin_web/endpoint.ex
+++ b/lib/lexin_web/endpoint.ex
@@ -15,7 +15,7 @@ defmodule LexinWeb.Endpoint do
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
   # No more than requests per minute from one IP address
-  @rate_per_minute 1000
+  @rate_per_minute 100
   plug :rate_limit
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lexin.MixProject do
   use Mix.Project
 
   @app :lexin
-  @version "0.18.0"
+  @version "0.18.1"
 
   def project do
     [


### PR DESCRIPTION
…for the testing purposes, as it seems that `siege` with 100 connections still gets the timeouts instead of being pushed back by a 429 response.

P.S. We have also moved configuration to simplify it for testing mode — 100 requests per minute is not enough for tests to run.